### PR TITLE
wip: Add native cmake build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Ifopt is a unified [Eigen]-based interface to use Nonlinear Programming solvers,
 
 ## <img align="center" height="20" src="https://i.imgur.com/x1morBF.png"/> Building
 
-* Install the cmake build tool [catkin]: ``$ sudo apt-get install ros-kinetic-catkin``
+This package can be built using either [catkin] or [CMake].
 
-* Install [Eigen]: ``$ sudo apt-get install libeigen3-dev``
-    
+### Generic
+* Install [CMake]: ``$ sudo apt-get install cmake``
+* Install [Eigen]: ``$ sudo apt-get install libeigen3-dev``   
 * Depending on which solver you want to use, install either [Ipopt] or [Snopt]. Follow the instructions provided here:
 
      * https://www.coin-or.org/Ipopt/documentation/node10.html (open source)
@@ -30,7 +31,8 @@ Ifopt is a unified [Eigen]-based interface to use Nonlinear Programming solvers,
 * To build [ifopt_snopt](ifopt_snopt) or [ifopt_ipopt](ifopt_ipopt) set the location of the shared 
 libraries and header files directly in the [CMakeLists.txt](https://github.com/ethz-adrl/ifopt/blob/fbf7acda4e3e42711031f65e015f6c9f84c87fbd/ifopt_ipopt/CMakeLists.txt#L16-L17) 
 of the corresponding solver.
-     
+### Catkin
+* Install the cmake build tool [catkin]: ``$ sudo apt-get install ros-kinetic-catkin``.  _     
 * Clone this repo into your [catkin] workspace and build
 
       $ cd catkin_workspace/src
@@ -40,7 +42,7 @@ of the corresponding solver.
       $ source ./devel/setup.bash
     
 
-## <img align="center" height="20" src="https://i.imgur.com/026nVBV.png"/> Unit Tests
+#### <img align="center" height="20" src="https://i.imgur.com/026nVBV.png"/> Unit Tests
 
 Make sure everything installed correctly by running the unit tests through
 
@@ -49,8 +51,28 @@ Make sure everything installed correctly by running the unit tests through
 This should also solve the [example problem](ifopt_core/include/ifopt/ex_problem.h) with your installed solvers. 
 If you have [IPOPT] installed and linked correctly, this should also execute the 
 binary [ifopt_ipopt-test](ifopt_ipopt/test/ex_test_ipopt.cc). 
-    
-     
+
+### CMake
+* Clone this repo and configure (``cd`` to desired directory before doing the following)
+
+      $ git clone https://github.com/ethz-adrl/ifopt.git
+      $ mkdir build ; cd build
+      $ cmake -DCATKIN_BUILD=OFF -DCMAKE_INSTALL_PREFIX=path_to_build_dir ..
+      
+Set ``path_to_build_dir`` to your desired installation target.
+
+* Build
+
+      $ make
+
+* Run unit tests
+
+      $ make test
+      
+* Install
+
+      $ make install
+      
 ## <img align="center" height="20" src="https://i.imgur.com/vAYeCzC.png"/> Usage
 
 For an example of how to use this to efficiently generate dynamic motions for legged robots, check-out [towr].
@@ -193,5 +215,6 @@ Please report bugs and request features using the [Issue Tracker](https://github
 [ROS]: http://www.ros.org
 [rviz]: http://wiki.ros.org/rviz
 [Fa2png]: http://fa2png.io/r/font-awesome/link/
+[CMake]: https://cmake.org/
 
 

--- a/ifopt/CMakeLists.txt
+++ b/ifopt/CMakeLists.txt
@@ -1,4 +1,63 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ifopt)
-find_package(catkin REQUIRED)
-catkin_metapackage()
+option(CATKIN_BUILD "CATKIN_BUILD" ON)
+MESSAGE(STATUS "CATKIN_BUILD is " ${CATKIN_BUILD})
+
+if(${CATKIN_BUILD})
+    find_package(catkin REQUIRED)
+    catkin_metapackage()
+else()
+    # do native cmake build
+    # add gtest and gmock support
+    # - see http://www.kaizou.org/2014/11/gtest-cmake/
+    # ------------- BEGIN FROM BLOG ------------------
+    # We need thread support
+    find_package(Threads REQUIRED)
+    
+    # Enable ExternalProject CMake module
+    include(ExternalProject)
+    
+    # Download and install GoogleTest
+    ExternalProject_Add(
+        gtest
+        URL https://github.com/google/googletest/archive/master.zip
+        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
+        # Disable install step
+        INSTALL_COMMAND ""
+    )
+                        
+    # Get GTest source and binary directories from CMake project
+    ExternalProject_Get_Property(gtest source_dir binary_dir)
+                        
+    # Create a libgtest target to be used as a dependency by test programs
+    add_library(libgtest IMPORTED STATIC GLOBAL)
+    add_dependencies(libgtest gtest)
+                        
+    # Set libgtest properties
+    set_target_properties(libgtest PROPERTIES
+        "IMPORTED_LOCATION" "${binary_dir}/googlemock/gtest/libgtest.a"
+        "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    )
+                                
+    # Create a libgmock target to be used as a dependency by test programs
+    add_library(libgmock IMPORTED STATIC GLOBAL)
+    add_dependencies(libgmock gtest)
+                                
+    # Set libgmock properties
+    set_target_properties(libgmock PROPERTIES
+        "IMPORTED_LOCATION" "${binary_dir}/googlemock/libgmock.a"
+        "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    )
+                                        
+    # I couldn't make it work with INTERFACE_INCLUDE_DIRECTORIES
+    include_directories("${source_dir}/googletest/include"
+        "${source_dir}/googlemock/include")
+    # ------------- END FROM BLOG ------------------
+    
+    enable_testing()
+    
+    # add subdirectories
+    add_subdirectory("../ifopt_core" "../../ifopt_core/build")
+    add_subdirectory("../ifopt_ipopt" "../../ifopt_ipopt/build")
+    add_subdirectory("../ifopt_snopt" "../../ifopt_snopt/build")
+endif()

--- a/ifopt_core/CMakeLists.txt
+++ b/ifopt_core/CMakeLists.txt
@@ -1,20 +1,21 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ifopt_core)
+option(CATKIN_BUILD "CATKIN_BUILD" ON)
 
 add_compile_options(-std=c++11)
 
-find_package(catkin REQUIRED)
 find_package(Eigen3 REQUIRED)
-
 
 ###################################
 ## catkin specific configuration ##
 ###################################
-catkin_package(
-  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
-  LIBRARIES    ${PROJECT_NAME}
-)
-
+if(${CATKIN_BUILD})
+    find_package(catkin REQUIRED)
+    catkin_package(
+      INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
+      LIBRARIES    ${PROJECT_NAME}
+    )
+endif()
 
 ###########
 ## Build ##
@@ -34,35 +35,54 @@ add_library(${PROJECT_NAME}
 #############
 ## Install ##
 #############
-# Mark library for installation
-install(
-  TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+if(${CATKIN_BUILD})
+    # Mark library for installation
+    install(
+      TARGETS ${PROJECT_NAME}
+      ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+      LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+      RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )
 
-# Mark header files for installation
-install(
-  DIRECTORY include/ifopt/
-  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ifopt
-  FILES_MATCHING PATTERN "*.h"
-)
-
-
-#############
-## Testing ##
-#############
-if (CATKIN_ENABLE_TESTING)
-catkin_add_gtest(${PROJECT_NAME}-test
-                 test/gtest_main.cc
-                 test/composite_test.cc
-                 test/problem_test.cc)
-if(TARGET ${PROJECT_NAME}-test)
-  target_link_libraries(${PROJECT_NAME}-test 
-    ${PROJECT_NAME}
-    pthread
-  )
+    # Mark header files for installation
+    install(
+      DIRECTORY include/ifopt/
+      DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ifopt
+      FILES_MATCHING PATTERN "*.h"
+    )
+    #############
+    ## Testing ##
+    #############
+    if (CATKIN_ENABLE_TESTING)
+    catkin_add_gtest(${PROJECT_NAME}-test
+                     test/gtest_main.cc
+                     test/composite_test.cc
+                     test/problem_test.cc)
+    if(TARGET ${PROJECT_NAME}-test)
+      target_link_libraries(${PROJECT_NAME}-test 
+        ${PROJECT_NAME}
+        pthread
+      )
+    endif()
+    endif()
+else()
+    # cmake native build
+    file(GLOB CORE_HFILES include/ifopt/*.h)
+    install(FILES ${CORE_HFILES}  DESTINATION include)
+    install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+    
+    #############
+    ## Testing ##
+    #############
+    file(GLOB CORE_TEST test/*.cc)
+    add_executable(${PROJECT_NAME}-test ${CORE_TEST})
+    target_link_libraries(${PROJECT_NAME}-test
+        ${PROJECT_NAME}
+        libgtest
+        libgmock
+        )
+    add_test(
+        NAME ${PROJECT_NAME}-test
+        COMMAND ${PROJECT_NAME}-test
+        )
 endif()
-endif()
-

--- a/ifopt_ipopt/CMakeLists.txt
+++ b/ifopt_ipopt/CMakeLists.txt
@@ -3,10 +3,6 @@ project(ifopt_ipopt)
 
 add_compile_options(-std=c++11)
 
-find_package(catkin REQUIRED)
-find_package(ifopt_core  REQUIRED)
-
-
 ################
 ## Find IPOPT ##
 ################
@@ -22,16 +18,18 @@ else()
   return()
 endif()
 
-
-#################################
-## Generate cmake config files ##
-#################################
-# These can then be used to "find_package(ifopt_ipopt)"
-catkin_package(
-  INCLUDE_DIRS include ${IPOPT_INCLUDE_DIRS} ${ifopt_core_INCLUDE_DIRS}
-  LIBRARIES    ${PROJECT_NAME}
-)
-
+if(${CATKIN_BUILD})
+    find_package(catkin REQUIRED)
+    find_package(ifopt_core  REQUIRED)
+    #################################
+    ## Generate cmake config files ##
+    #################################
+    # These can then be used to "find_package(ifopt_ipopt)"
+    catkin_package(
+        INCLUDE_DIRS include ${IPOPT_INCLUDE_DIRS} ${ifopt_core_INCLUDE_DIRS}
+        LIBRARIES    ${PROJECT_NAME}
+    )
+endif()
 
 ###########
 ## Build ##
@@ -49,37 +47,58 @@ target_link_libraries(${PROJECT_NAME}
   ${IPOPT_LIBRARIES}
 )
 
-
 #############
 ## Install ##
 #############
 # For this to work, first make sure IPOPT headers and library are installed
 # somewhere in the default search paths.
 # Mark library for installation
-install(
-  TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+if(${CATKIN_BUILD})
+    install(
+      TARGETS ${PROJECT_NAME}
+      ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+      LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+      RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )
 
-# Mark header files for installation
-install(
-  DIRECTORY include/ifopt_ipopt/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
-)
+    # Mark header files for installation
+    install(
+      DIRECTORY include/ifopt_ipopt/
+      DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+      FILES_MATCHING PATTERN "*.h"
+    )
 
+    #############
+    ## Testing ##
+    #############
+    if (CATKIN_ENABLE_TESTING)
+    catkin_add_gtest(${PROJECT_NAME}-test test/ex_test_ipopt.cc)
+    if(TARGET ${PROJECT_NAME}-test)
+      target_link_libraries(${PROJECT_NAME}-test 
+        ${PROJECT_NAME}
+        pthread
+      )
+    endif()
+    endif()
+else()
+    # cmake native build
+    file(GLOB IPOPT_HFILES include/ifopt_ipopt/*.h)
+    install(FILES ${IPOPT_HFILES} DESTINATION include)
+    install(TARGETS ${PROJECT_NAME} DESTINATION lib)
 
-#############
-## Testing ##
-#############
-if (CATKIN_ENABLE_TESTING)
-catkin_add_gtest(${PROJECT_NAME}-test test/ex_test_ipopt.cc)
-if(TARGET ${PROJECT_NAME}-test)
-  target_link_libraries(${PROJECT_NAME}-test 
-    ${PROJECT_NAME}
-    pthread
-  )
-endif()
+    #############
+    ## Testing ##
+    #############
+    file(GLOB IPOPT_TEST test/*.cc)
+    add_executable(${PROJECT_NAME}-test ${IPOPT_TEST})
+    target_link_libraries(${PROJECT_NAME}-test
+        ${PROJECT_NAME}
+        libgtest
+        libgmock
+        )
+    
+    add_test(
+        NAME ${PROJECT_NAME}-test
+        COMMAND ${PROJECT_NAME}-test
+        )
 endif()

--- a/ifopt_snopt/CMakeLists.txt
+++ b/ifopt_snopt/CMakeLists.txt
@@ -3,10 +3,6 @@ project(ifopt_snopt)
 
 add_compile_options(-std=c++11)
 
-find_package(catkin REQUIRED)
-find_package(ifopt_core REQUIRED)
-
-
 ################
 ## Find SNOPT ##
 ################
@@ -29,16 +25,18 @@ if(${SNOPT76})
   message("SNOPT76 version >= SNOPT 7.6 detected")
 endif()
 
-
-#################################
-## Generate cmake config files ##
-#################################
-# These can then be used to "find_package(ifopt_snopt)"
-catkin_package(
-  INCLUDE_DIRS include ${SNOPT_INCLUDE_DIRS} ${ifopt_core_INCLUDE_DIRS}
-  LIBRARIES    ${PROJECT_NAME}
-)
-
+if(${CATKIN_BUILD})
+    find_package(catkin REQUIRED)
+    find_package(ifopt_core REQUIRED)
+    #################################
+    ## Generate cmake config files ##
+    #################################
+    # These can then be used to "find_package(ifopt_snopt)"
+    catkin_package(
+      INCLUDE_DIRS include ${SNOPT_INCLUDE_DIRS} ${ifopt_core_INCLUDE_DIRS}
+      LIBRARIES    ${PROJECT_NAME}
+    )
+endif()
 
 ###########
 ## Build ##
@@ -61,42 +59,69 @@ target_link_libraries(${PROJECT_NAME}
   ${SNOPT_LIB2}
 )
 
-
 #############
 ## Install ##
 #############
 # For this to work, first make sure IPOPT headers and library are installed
 # somewhere in the default search paths.
-# Mark library for installation
-install(
-  TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+if(${CATKIN_BUILD})
+    # Mark library for installation
+    install(
+      TARGETS ${PROJECT_NAME}
+      ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+      LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+      RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )
 
-# Mark header files for installation
-install(
-  DIRECTORY include/ifopt_snopt/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
-)
+    # Mark header files for installation
+    install(
+      DIRECTORY include/ifopt_snopt/
+      DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+      FILES_MATCHING PATTERN "*.h"
+    )
 
 
-#############
-## Testing ##
-#############
-if (CATKIN_ENABLE_TESTING)
-catkin_add_gtest(${PROJECT_NAME}-test test/ex_test_snopt.cc)
+    #############
+    ## Testing ##
+    #############
+    if (CATKIN_ENABLE_TESTING)
+    catkin_add_gtest(${PROJECT_NAME}-test test/ex_test_snopt.cc)
 
-if(${SNOPT76})
-  target_compile_definitions(${PROJECT_NAME}-test PRIVATE SNOPT76_ON=1)
-endif()
+    if(${SNOPT76})
+      target_compile_definitions(${PROJECT_NAME}-test PRIVATE SNOPT76_ON=1)
+    endif()
 
-if(TARGET ${PROJECT_NAME}-test)
-  target_link_libraries(${PROJECT_NAME}-test 
-    ${PROJECT_NAME}
-    pthread
-  )
-endif()
+    if(TARGET ${PROJECT_NAME}-test)
+      target_link_libraries(${PROJECT_NAME}-test 
+        ${PROJECT_NAME}
+        pthread
+      )
+    endif()
+    endif()
+else()
+    # cmake native build
+    file(GLOB SNOPT_HFILES include/ifopt_snopt/*.h)
+    install(FILES ${SNOPT_HFILES} DESTINATION include)
+    install(TARGETS ${PROJECT_NAME} lib)
+    
+    #############
+    ## Testing ##
+    #############
+    file(GLOB SNOPT_TEST test/*.cc)
+    add_executable(${PROJECT_NAME}-test ${SNOPT_TEST})
+    
+    if(${SNOPT76})
+      target_compile_definitions(${PROJECT_NAME}-test PRIVATE SNOPT76_ON=1)
+    endif()
+    
+    target_link_libraries(${PROJECT_NAME}-test
+        ${PROJECT_NAME}
+        libgtest
+        libgmock
+        )
+    
+    add_test(
+        NAME ${PROJECT_NAME}-test
+        COMMAND ${PROJECT_NAME}-test
+        )
 endif()


### PR DESCRIPTION
It would be nice not to have to rely upon catkin bindings to build ifopt.  I have created a process to do just that.  I have also updated the README to explain it.

The main thing is the addition of the ``CATKIN_BUILD`` option.  By default, ``CATKIN_BUILD=ON``, meaning that cmake will try to build using catkin; it will look for all of the correct packages etc...  The build process with catkin should be just the same as before, but someone should verify via CI or manual test.

I was able to build and run using the instructions.  Please let me know if you encounter any issues with this PR.  Cheers!