### PR TITLE
Implemented more efficient method for building constraint jacobian

### DIFF
--- a/ifopt_core/src/composite.cc
+++ b/ifopt_core/src/composite.cc
@@ -138,7 +138,7 @@ Composite::GetJacobian () const
 
     for (int k=0; k<jac.outerSize(); ++k)
       for (Jacobian::InnerIterator it(jac,k); it; ++it)
-          triplet_list.push_back(Eigen::Triplet<double>(row+it.row(),it.col(),it.value()));
+        triplet_list.push_back(Eigen::Triplet<double>(row+it.row(), it.col(), it.value()));
 
     if (!is_cost_)
       row += c->GetRows();

--- a/ifopt_core/src/composite.cc
+++ b/ifopt_core/src/composite.cc
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
 Copyright (c) 2017, Alexander W Winkler. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -130,16 +130,21 @@ Composite::GetJacobian () const
   Jacobian jacobian(GetRows(), n_var);
 
   int row = 0;
+  std::vector< Eigen::Triplet<double> > triplet_list;
+
   for (const auto& c : components_) {
     const Jacobian& jac = c->GetJacobian();
+    triplet_list.reserve(triplet_list.size()+jac.nonZeros());
+
     for (int k=0; k<jac.outerSize(); ++k)
       for (Jacobian::InnerIterator it(jac,k); it; ++it)
-        jacobian.coeffRef(row+it.row(), it.col()) += it.value();
+          triplet_list.push_back(Eigen::Triplet<double>(row+it.row(),it.col(),it.value()));
 
     if (!is_cost_)
       row += c->GetRows();
   }
 
+  jacobian.setFromTriplets(triplet_list.begin(), triplet_list.end());
   return jacobian;
 }
 

--- a/ifopt_core/src/leaves.cc
+++ b/ifopt_core/src/leaves.cc
@@ -50,12 +50,12 @@ ConstraintSet::GetJacobian () const
   Jacobian jacobian(GetRows(), variables_->GetRows());
 
   int col = 0;
-  Jacobian jac = Jacobian(GetRows(), 1);
+  Jacobian jac;
   std::vector< Eigen::Triplet<double> > triplet_list;
 
   for (const auto& vars : variables_->GetComponents()) {
     int n = vars->GetRows();
-    jac.resize(GetRows(),n);
+    jac.resize(GetRows(), n);
 
     FillJacobianBlock(vars->GetName(), jac);
     // reserve space for the new elements to reduce memory allocation
@@ -64,7 +64,7 @@ ConstraintSet::GetJacobian () const
     // create triplets for the derivative at the correct position in the overall Jacobian
     for (int k=0; k<jac.outerSize(); ++k)
       for (Jacobian::InnerIterator it(jac,k); it; ++it)
-         triplet_list.push_back(Eigen::Triplet<double>(it.row(),col+it.col(),it.value()));
+        triplet_list.push_back(Eigen::Triplet<double>(it.row(), col+it.col(), it.value()));
     col += n;
   }
 


### PR DESCRIPTION
_coeffRef_ is in comparison to _setFromTriplets_ a quite costly operation.

Tests showed a reduction of computation time with this solution of 30 up to over 50 percent depending on the problem size.
 
_setFromTriplets_ also considers multiple entries for the same indices and adds them up, so there is no issue that += in line 137 of composite.cc was used earlier.
Further details can be found here:
https://eigen.tuxfamily.org/dox/group__TutorialSparse.html#TutorialSparseFilling