### PR TITLE
Fix/segfaults

### DIFF
--- a/ifopt_ipopt/include/ifopt/ipopt_adapter.h
+++ b/ifopt_ipopt/include/ifopt/ipopt_adapter.h
@@ -31,6 +31,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <IpIpoptApplication.hpp>
 #include <IpSolveStatistics.hpp>
 
+#include <ifopt/ipopt_solver.h>
 #include <ifopt/problem.h>
 
 /**
@@ -64,10 +65,12 @@ public:
    * This constructor holds and modifies the passed nlp.
    */
   IpoptAdapter(Problem& nlp);
+  IpoptAdapter(Problem& nlp, const std::shared_ptr<Ipopt::IpoptApplication>& ipopt_app);
   virtual ~IpoptAdapter() = default;
 
 private:
   Problem* nlp_; ///< The solver independent problem definition
+  std::string jacobian_method;  ///< String variable to check the Jacobian evaluation method: "exact" or "finite-difference-values"
 
   /** Method to return some info about the nlp */
   virtual bool get_nlp_info(Index& n, Index& m, Index& nnz_jac_g,

--- a/ifopt_ipopt/include/ifopt/ipopt_solver.h
+++ b/ifopt_ipopt/include/ifopt/ipopt_solver.h
@@ -57,12 +57,17 @@ public:
     */
   void Solve(Problem& nlp) override;
 
-  /** Options for the IPOPT solver. A complete list can be found here:
+  /** Set options for the IPOPT solver. A complete list can be found here:
     * https://www.coin-or.org/Ipopt/documentation/node40.html
     */
   void SetOption(const std::string& name, const std::string& value);
   void SetOption(const std::string& name, int value);
   void SetOption(const std::string& name, double value);
+
+  /** Get options of the IPOPT solver.
+    */
+  void GetStringOption(const std::string& name, std::string& value, const std::string& prefix);
+  void GetStringOption(const std::string& name, std::string& value);
 
 private:
   std::shared_ptr<Ipopt::IpoptApplication> ipopt_app_;

--- a/ifopt_ipopt/src/ipopt_adapter.cc
+++ b/ifopt_ipopt/src/ipopt_adapter.cc
@@ -24,7 +24,6 @@ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************************************************************/
 
-#include <iostream>
 #include <ifopt/ipopt_adapter.h>
 #include <ifopt/ipopt_solver.h>
 

--- a/ifopt_ipopt/src/ipopt_solver.cc
+++ b/ifopt_ipopt/src/ipopt_solver.cc
@@ -71,7 +71,7 @@ IpoptSolver::Solve (Problem& nlp)
   }
 
   // convert the NLP problem to Ipopt
-  SmartPtr<TNLP> nlp_ptr = new IpoptAdapter(nlp);
+  SmartPtr<TNLP> nlp_ptr = new IpoptAdapter(nlp,ipopt_app_);
   status_ = ipopt_app_->OptimizeTNLP(nlp_ptr);
 
   if (status_ != Solve_Succeeded) {
@@ -96,6 +96,18 @@ void
 IpoptSolver::SetOption (const std::string& name, double value)
 {
   ipopt_app_->Options()->SetNumericValue(name, value);
+}
+
+void
+IpoptSolver::GetStringOption (const std::string& name, std::string& value, const std::string& prefix)
+{
+  ipopt_app_->Options()->GetStringValue(name, value, prefix);
+}
+
+void
+IpoptSolver::GetStringOption (const std::string& name, std::string& value)
+{
+  ipopt_app_->Options()->GetStringValue(name, value, "");
 }
 
 } /* namespace ifopt */

--- a/ifopt_ipopt/test/ex_test_ipopt.cc
+++ b/ifopt_ipopt/test/ex_test_ipopt.cc
@@ -44,7 +44,8 @@ int main()
   // 2. choose solver and options
   IpoptSolver ipopt;
   ipopt.SetOption("linear_solver", "mumps");
-  ipopt.SetOption("jacobian_approximation", "exact");
+  //ipopt.SetOption("jacobian_approximation", "exact");
+  ipopt.SetOption("jacobian_approximation", "finite-difference-values");
 
   // 3 . solve
   ipopt.Solve(nlp);


### PR DESCRIPTION
When the user chooses to use the "finite-difference-values" method for the "jacobian_approximation" option, it should be possible to leave the FillJacobianBlock function of the constraint class empty. However, Ifopt uses the Jacobian defined by the user to determine the number of non-zero elements in the constraint Jacobian, necessary information for interfacing the problem with Ipopt. 

https://github.com/ethz-adrl/ifopt/blob/b567a0eac7651c8d1091f2c5db2036e85871dc17/ifopt_ipopt/src/ipopt_adapter.cc#L42

The result is a Segmentation Fault when the constraint Jacobian was not defined by the user (because nnz_jac_g is defined as zero), even if "jacobian_approximation" is set to "finite-difference-values".

The solution I implemented is to use a dense Jacobian when the "finite-difference-values" option is set, which always works. The downside is, if the user did define the sparse structure for the Jacobian and the "finite-difference-values" option is set, Ifopt will still use a dense matrix instead of the sparse, which most likely will increase the computational cost. 

Unless the number of non-zeros elements in the constraint Jacobian is also a user entry in Ifopt, I don't see a better way to fix this.
