### PR TITLE
Make FillJacobianBlock public in ConstraintSet

### DIFF
--- a/ifopt_core/include/ifopt/constraint_set.h
+++ b/ifopt_core/include/ifopt/constraint_set.h
@@ -82,15 +82,6 @@ public:
    */
   Jacobian GetJacobian() const final;
 
-protected:
-  /**
-   * @brief Read access to the value of the optimization variables.
-   *
-   * This must be used to formulate the constraint violation and Jacobian.
-   */
-  const VariablesPtr GetVariables() const { return variables_; };
-
-private:
   /**
    * @brief Set individual Jacobians corresponding to each decision variable set.
    * @param var_set  Set of variables the current Jacobian block belongs to.
@@ -107,6 +98,16 @@ private:
    * simply do nothing.
    */
   virtual void FillJacobianBlock(std::string var_set, Jacobian& jac_block) const = 0;
+
+protected:
+  /**
+   * @brief Read access to the value of the optimization variables.
+   *
+   * This must be used to formulate the constraint violation and Jacobian.
+   */
+  const VariablesPtr GetVariables() const { return variables_; };
+
+private:
   VariablesPtr variables_;
 
   /**


### PR DESCRIPTION
By allowing this to be externally callable, we are able to make costs and constraints that modify costs and constraints passed into them.

An example is [the squared cost](https://github.com/mpowelson/trajopt_ros/blob/archive/ifopt_squared_cost/trajopt_ifopt/include/trajopt_ifopt/squared_cost.h) I made in order to address [towr issue 72](https://github.com/ethz-adrl/towr/issues/72). The idea is that you can calculate any values you want as constraints and the pass them into this squared cost to convert them to into a squared cost. The issue was that I was only able to call the GetJacobian of the contained constraint which I would then have to decompose into the form that FillJacobianBlock needs. By exposing the constraint FillJacobianBlock, I can get only the pieces that the constraint I am modifying needs.