### PR TITLE
Add GetJacobianOfCosts to Problem

### DIFF
--- a/ifopt_core/include/ifopt/problem.h
+++ b/ifopt_core/include/ifopt/problem.h
@@ -205,6 +205,14 @@ public:
   Jacobian GetJacobianOfConstraints() const;
 
   /**
+   * @brief The sparse-matrix representation of Jacobian of the costs.
+   *
+   * Returns one row corresponding to the costs and each column corresponding
+   * to an optimizaton variable.
+   */
+  Jacobian GetJacobianOfCosts () const;
+
+  /**
    * @brief Saves the current values of the optimization variables in x_prev.
    *
    * This is used to keep a history of the values for each NLP iterations.

--- a/ifopt_core/src/problem.cc
+++ b/ifopt_core/src/problem.cc
@@ -149,6 +149,12 @@ Problem::GetJacobianOfConstraints () const
   return constraints_.GetJacobian();
 }
 
+Problem::Jacobian
+Problem::GetJacobianOfCosts () const
+{
+  return costs_.GetJacobian();
+}
+
 void
 Problem::SaveCurrent()
 {


### PR DESCRIPTION
The mirrors the GetJacobianOfConstraints that already exists. I didn't see any immediate reason why this was left out. It seems useful for debugging. There is already `EvaluateCostFunctionGradient`, but it requires that you set the variables rather than just returning what is already set.