### PR TITLE
Switch between catkin and ament based on ROS_VERSION

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<package format="2">
+<package format="3">
   <name>ifopt</name>
   <version>2.0.7</version>
   <description>
@@ -23,7 +23,8 @@
   <depend>coinor-libipopt-dev</depend> 
   
   <!-- The following tags are recommended by REP-136 -->
-  <exec_depend>catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
   <buildtool_depend>cmake</buildtool_depend>
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
This makes it easier to use with ROS 2. Otherwise you have to add a rosdep skip-key on catkin. REP-136 looks to be well before ROS 2 and ament were in the picture.