### PR TITLE
Add method to check component name duplication

### DIFF
--- a/ifopt_core/include/ifopt/constraint_set.h
+++ b/ifopt_core/include/ifopt/constraint_set.h
@@ -125,10 +125,10 @@ private:
    * or shorthands to specific variable sets want to be saved for quicker
    * access later. This function can be overwritten for that.
    */
-  virtual void InitVariableDependedQuantities(const VariablesPtr& x_init) {};
+  virtual void InitVariableDependedQuantities(const VariablesPtr&) {};
 
   // doesn't exist for constraints, generated run-time error when used
-  void SetVariables(const VectorXd& x) final { assert(false); };
+  void SetVariables(const VectorXd&) final { assert(false); };
 };
 
 

--- a/ifopt_core/include/ifopt/problem.h
+++ b/ifopt_core/include/ifopt/problem.h
@@ -260,6 +260,12 @@ public:
    */
   const Composite& GetCosts() const { return costs_; };
 
+  /**
+   * @brief Find duplicate component name
+   * @return Duplicate component name if found, otherwise empty
+   */
+  std::string FindDuplicateComponentName() const;
+
 private:
   Composite::Ptr variables_;
   Composite constraints_;

--- a/ifopt_core/src/problem.cc
+++ b/ifopt_core/src/problem.cc
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ifopt/problem.h>
 #include <iostream>
 #include <iomanip>
+#include <set>
 
 
 namespace ifopt {
@@ -221,7 +222,37 @@ Problem::PrintCurrent() const
   variables_->PrintAll();
   constraints_.PrintAll();
   costs_.PrintAll();
-};
+}
+
+std::string
+Problem::FindDuplicateComponentName () const
+{
+  auto check_composite = [](const auto& components, std::string& name) -> bool {
+    std::set<std::string> names;
+    for (const auto& c : components) {
+      if (names.count(c->GetName())) {
+        name = c->GetName();
+        return true;
+      }
+      names.insert(c->GetName());
+    }
+    return false;
+  };
+
+  std::string ret = "";
+
+  if (check_composite(variables_->GetComponents(), ret)) {
+    return ret;
+  }
+  if (check_composite(constraints_.GetComponents(), ret)) {
+    return ret;
+  }
+  if (check_composite(costs_.GetComponents(), ret)) {
+    return ret;
+  }
+
+  return ret;
+}
 
 Problem::VectorXd
 Problem::ConvertToEigen(const double* x) const


### PR DESCRIPTION
If components (e.g., variables, constraints, costs) contain components with the same name, it seems that an unexpected problem will arise (is this understanding correct?)
This Pull Request adds a method to check the name duplication to the `Problem` class. Doing the same thing in user code is difficult because `variables_` is private and there is no access method.

(This is a utility that I use locally. It may be worth sharing in the origin repository, so I'll make a pull request.)