### PR TITLE
(#77) Implement Required Method

### DIFF
--- a/ifopt_core/include/ifopt/problem.h
+++ b/ifopt_core/include/ifopt/problem.h
@@ -260,6 +260,12 @@ public:
    */
   const Composite& GetCosts() const { return costs_; };
 
+  /**
+   * @brief Read access to the history of iterations
+   * @return A const reference to x_prev
+   */
+  const std::vector<VectorXd> &GetIterations() const { return x_prev; };
+
 private:
   Composite::Ptr variables_;
   Composite constraints_;


### PR DESCRIPTION
This pull request address the issue #77. 

It only implements the method `ifopt::Problem::GetIterations` as
```C++
const std::vector<VectorXd> &GetIterations() const { return x_prev; };
```