### PR TITLE
Fix CMake install() rules for Windows DLLs

### DIFF
--- a/ifopt_core/CMakeLists.txt
+++ b/ifopt_core/CMakeLists.txt
@@ -33,6 +33,7 @@ install(
   EXPORT  ${LIB_CORE}-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 # Copy header files to usr/local/include/ifopt/*
 install(

--- a/ifopt_ipopt/CMakeLists.txt
+++ b/ifopt_ipopt/CMakeLists.txt
@@ -49,12 +49,17 @@ add_test(${LIB_IPOPT}-example ${LIB_IPOPT}-example)
 #############
  # Copy library files to usr/local/lib/libifopt_ipopt.so
 install(
-  TARGETS ${LIB_IPOPT} ${LIB_IPOPT}-example
+  TARGETS ${LIB_IPOPT}
   EXPORT  ${LIB_IPOPT}-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${IFOPT_INSTALL_BINDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+# install example executable
+install(
+  TARGETS ${LIB_IPOPT}-example
+  RUNTIME DESTINATION ${IFOPT_INSTALL_BINDIR}
 )
 # Copy header files to usr/local/include/ifopt/*
 install(DIRECTORY include/ifopt/

--- a/ifopt_snopt/CMakeLists.txt
+++ b/ifopt_snopt/CMakeLists.txt
@@ -47,10 +47,15 @@ add_test(${LIB_SNOPT}-example ${LIB_SNOPT}-example)
 #############
  # Copy library files to usr/local/lib/libifopt_snopt.so
 install(
-  TARGETS ${LIB_SNOPT} ${LIB_SNOPT}-example
+  TARGETS ${LIB_SNOPT}
   EXPORT ${LIB_SNOPT}-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+# install sample executable
+install(
+  TARGETS ${LIB_SNOPT}-example
   RUNTIME DESTINATION ${IFOPT_INSTALL_BINDIR}
 )
 # Copy header files to usr/local/include/ifopt/*


### PR DESCRIPTION
When building on Windows, CMake use the `RUNTIME` destination argument as the install location for the DLL files. This change slightly modifies the `install()` calls to put them where they are expected, under `bin/`, and to separate installation of libraries and executables.