### PR TITLE
Rethrow nonIpopt exceptions

### DIFF
--- a/ifopt_ipopt/include/ifopt/ipopt_solver.h
+++ b/ifopt_ipopt/include/ifopt/ipopt_solver.h
@@ -49,7 +49,7 @@ class IpoptSolver : public Solver {
 public:
   using Ptr = std::shared_ptr<IpoptSolver>;
 
-  IpoptSolver();
+  IpoptSolver(bool rethrow_non_ipopt_exceptions = false);
   virtual ~IpoptSolver() = default;
 
   /** @brief  Creates an IpoptAdapter and solves the NLP.

--- a/ifopt_ipopt/src/ipopt_solver.cc
+++ b/ifopt_ipopt/src/ipopt_solver.cc
@@ -58,6 +58,9 @@ IpoptSolver::IpoptSolver()
   // SetOption("max_iter", 1);
   // SetOption("derivative_test", "first-order");
   // SetOption("derivative_test_tol", 1e-3);
+
+  // Enable throwing original exceptions for catching errors
+  ipopt_app_->RethrowNonIpoptException(true);
 }
 
 void

--- a/ifopt_ipopt/src/ipopt_solver.cc
+++ b/ifopt_ipopt/src/ipopt_solver.cc
@@ -29,7 +29,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace ifopt {
 
-IpoptSolver::IpoptSolver()
+IpoptSolver::IpoptSolver(bool rethrow_non_ipopt_exceptions)
 {
   ipopt_app_ = std::make_shared<Ipopt::IpoptApplication>();
   status_ = Ipopt::Solve_Succeeded;
@@ -59,8 +59,8 @@ IpoptSolver::IpoptSolver()
   // SetOption("derivative_test", "first-order");
   // SetOption("derivative_test_tol", 1e-3);
 
-  // Enable throwing original exceptions for catching errors
-  ipopt_app_->RethrowNonIpoptException(true);
+  // Enable or Disable throwing original exceptions for catching errors
+  ipopt_app_->RethrowNonIpoptException(rethrow_non_ipopt_exceptions);
 }
 
 void


### PR DESCRIPTION
Many times it is useful to see where our code has broken (e.g. wrong memory access). This PR makes possible to tell to the `Ipopt` solver to throw non-Ipopt exceptions so that we can catch them outside and deal with the issue in a better manner. By default the behavior is as before (i.e. Ipopt catches them and returns `Unknown File Exception`).