### PR TITLE
Apply Google Style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build
 doc/html
+.vscode
+*.code-workspace

--- a/ifopt_core/include/ifopt/bounds.h
+++ b/ifopt_core/include/ifopt/bounds.h
@@ -65,10 +65,10 @@ struct Bounds {
 static const double inf = 1.0e20;
 
 static const Bounds NoBound          = Bounds(-inf, +inf);
-static const Bounds BoundZero        = Bounds( 0.0,  0.0);
-static const Bounds BoundGreaterZero = Bounds( 0.0, +inf);
-static const Bounds BoundSmallerZero = Bounds(-inf,  0.0);
+static const Bounds BoundZero        = Bounds(0.0, 0.0);
+static const Bounds BoundGreaterZero = Bounds(0.0, +inf);
+static const Bounds BoundSmallerZero = Bounds(-inf, 0.0);
 
-} // namespace opt
+}  // namespace ifopt
 
 #endif /* IFOPT_INCLUDE_OPT_BOUNDS_H_ */

--- a/ifopt_core/include/ifopt/composite.h
+++ b/ifopt_core/include/ifopt/composite.h
@@ -61,8 +61,8 @@ namespace ifopt {
  * the composite pattern visit https://sourcemaking.com/design_patterns/composite
  */
 class Component {
-public:
-  using Ptr  = std::shared_ptr<Component>;
+ public:
+  using Ptr = std::shared_ptr<Component>;
 
   using Jacobian = Eigen::SparseMatrix<double, Eigen::RowMajor>;
   using VectorXd = Eigen::VectorXd;
@@ -142,12 +142,10 @@ public:
   void SetRows(int num_rows);
   static const int kSpecifyLater = -1;
 
-private:
+ private:
   int num_rows_ = kSpecifyLater;
   std::string name_;
 };
-
-
 
 /**
  * @brief A collection of components which is treated as another Component.
@@ -160,8 +158,8 @@ private:
  * See Component and Composite Pattern for more information.
  */
 class Composite : public Component {
-public:
-  using Ptr = std::shared_ptr<Composite>;
+ public:
+  using Ptr          = std::shared_ptr<Composite>;
   using ComponentVec = std::vector<Component::Ptr>;
 
   /**
@@ -176,9 +174,9 @@ public:
   virtual ~Composite() = default;
 
   // see Component for documentation
-  VectorXd GetValues   () const override;
-  Jacobian GetJacobian () const override;
-  VecBound GetBounds   () const override;
+  VectorXd GetValues() const override;
+  Jacobian GetJacobian() const override;
+  VecBound GetBounds() const override;
   void SetVariables(const VectorXd& x) override;
   void PrintAll() const;
 
@@ -195,13 +193,13 @@ public:
    * @tparam T  Type of component.
    * @return A type-casted pointer possibly providing addtional functionality.
    */
-  template<typename T> std::shared_ptr<T>
-  GetComponent(const std::string& name) const;
+  template <typename T>
+  std::shared_ptr<T> GetComponent(const std::string& name) const;
 
   /**
    * @brief Adds a component to this composite.
    */
-  void AddComponent (const Component::Ptr&);
+  void AddComponent(const Component::Ptr&);
 
   /**
    * @brief Removes all component from this composite.
@@ -213,24 +211,22 @@ public:
    */
   const ComponentVec GetComponents() const;
 
-private:
+ private:
   ComponentVec components_;
   bool is_cost_;
   // The number of variables for costs/constraint composites (not set for variables).
   // Is initialized the first the GetJacobian() is called.
-  mutable size_t n_var = -1; 
+  mutable size_t n_var = -1;
 };
 
-
 // implementation of template functions
-template<typename T>
+template <typename T>
 std::shared_ptr<T> Composite::GetComponent(const std::string& name) const
 {
   Component::Ptr c = GetComponent(name);
   return std::dynamic_pointer_cast<T>(c);
 }
 
-
-} /* namespace opt */
+}  // namespace ifopt
 
 #endif /* IFOPT_INCLUDE_OPT_COMPOSITE_H_ */

--- a/ifopt_core/include/ifopt/constraint_set.h
+++ b/ifopt_core/include/ifopt/constraint_set.h
@@ -49,7 +49,7 @@ namespace ifopt {
  * @sa Component
  */
 class ConstraintSet : public Component {
-public:
+ public:
   using Ptr          = std::shared_ptr<ConstraintSet>;
   using VariablesPtr = Composite::Ptr;
 
@@ -104,9 +104,10 @@ public:
    * set as follows (which can also be set =0.0 without erros):
    * jac_block.coeffRef(1, 3) = ... 
    */
-  virtual void FillJacobianBlock(std::string var_set, Jacobian& jac_block) const = 0;
+  virtual void FillJacobianBlock(std::string var_set,
+                                 Jacobian& jac_block) const = 0;
 
-protected:
+ protected:
   /**
    * @brief Read access to the value of the optimization variables.
    *
@@ -114,7 +115,7 @@ protected:
    */
   const VariablesPtr GetVariables() const { return variables_; };
 
-private:
+ private:
   VariablesPtr variables_;
 
   /**
@@ -125,14 +126,12 @@ private:
    * or shorthands to specific variable sets want to be saved for quicker
    * access later. This function can be overwritten for that.
    */
-  virtual void InitVariableDependedQuantities(const VariablesPtr& x_init) {};
+  virtual void InitVariableDependedQuantities(const VariablesPtr& x_init){};
 
   // doesn't exist for constraints, generated run-time error when used
   void SetVariables(const VectorXd& x) final { assert(false); };
 };
 
-
-} // namespace ifopt
-
+}  // namespace ifopt
 
 #endif /* IFOPT_INCLUDE_IFOPT_CONSTRAINT_SET_H_ */

--- a/ifopt_core/include/ifopt/cost_term.h
+++ b/ifopt_core/include/ifopt/cost_term.h
@@ -44,17 +44,17 @@ namespace ifopt {
  * @sa Component
  */
 class CostTerm : public ConstraintSet {
-public:
+ public:
   CostTerm(const std::string& name);
   virtual ~CostTerm() = default;
 
-private:
+ private:
   /**
    * @brief  Returns the scalar cost term calculated from the @c variables.
    */
   virtual double GetCost() const = 0;
 
-public:
+ public:
   /**
    * @brief  Wrapper function that converts double to Eigen::VectorXd.
    */
@@ -68,9 +68,9 @@ public:
   /**
    * Cost term printout slightly different from variables/constraints.
    */
-  void Print (double tol, int& index) const final;
+  void Print(double tol, int& index) const final;
 };
 
-}
+}  // namespace ifopt
 
 #endif /* IFOPT_INCLUDE_IFOPT_COST_TERM_H_ */

--- a/ifopt_core/include/ifopt/problem.h
+++ b/ifopt_core/include/ifopt/problem.h
@@ -30,15 +30,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef IFOPT_INCLUDE_OPT_PROBLEM_H_
 #define IFOPT_INCLUDE_OPT_PROBLEM_H_
 
-#include "variable_set.h"
 #include "constraint_set.h"
 #include "cost_term.h"
+#include "variable_set.h"
 
 /**
  * @brief common namespace for all elements in this library.
  */
 namespace ifopt {
-
 
 /**
  * @defgroup ProblemFormulation
@@ -95,7 +94,7 @@ namespace ifopt {
  * See @ref Solvers for currently implemented solvers.
  */
 class Problem {
-public:
+ public:
   using VecBound = Component::VecBound;
   using Jacobian = Component::Jacobian;
   using VectorXd = Component::VectorXd;
@@ -103,8 +102,8 @@ public:
   /**
    * @brief  Creates a optimization problem with no variables, costs or constraints.
    */
-  Problem ();
-  virtual ~Problem () = default;
+  Problem();
+  virtual ~Problem() = default;
 
   /**
    * @brief Add one individual set of variables to the optimization problem.
@@ -174,9 +173,9 @@ public:
    * @details ipopt uses 10e-8 for their derivative check, but setting here to more precise
    * https://coin-or.github.io/Ipopt/OPTIONS.html#OPT_derivative_test_perturbation
    */
-  VectorXd EvaluateCostFunctionGradient(const double* x,
-                                        bool use_finite_difference_approximation = false,
-                                        double epsilon = std::numeric_limits<double>::epsilon());
+  VectorXd EvaluateCostFunctionGradient(
+      const double* x, bool use_finite_difference_approximation = false,
+      double epsilon = std::numeric_limits<double>::epsilon());
 
   /**
    * @brief The number of individual constraints.
@@ -214,7 +213,7 @@ public:
    * Returns one row corresponding to the costs and each column corresponding
    * to an optimizaton variable.
    */
-  Jacobian GetJacobianOfCosts () const;
+  Jacobian GetJacobianOfCosts() const;
 
   /**
    * @brief Saves the current values of the optimization variables in x_prev.
@@ -264,18 +263,18 @@ public:
    * @brief Read access to the history of iterations
    * @return A const reference to x_prev
    */
-  const std::vector<VectorXd> &GetIterations() const { return x_prev; };
+  const std::vector<VectorXd>& GetIterations() const { return x_prev; };
 
-private:
+ private:
   Composite::Ptr variables_;
   Composite constraints_;
   Composite costs_;
 
-  std::vector<VectorXd> x_prev; ///< the pure variables for every iteration.
+  std::vector<VectorXd> x_prev;  ///< the pure variables for every iteration.
 
   VectorXd ConvertToEigen(const double* x) const;
 };
 
-} /* namespace opt */
+}  // namespace ifopt
 
 #endif /* IFOPT_INCLUDE_OPT_PROBLEM_H_ */

--- a/ifopt_core/include/ifopt/solver.h
+++ b/ifopt_core/include/ifopt/solver.h
@@ -46,24 +46,23 @@ namespace ifopt {
  * @ingroup Solvers
  */
 class Solver {
-public:
+ public:
   using Ptr = std::shared_ptr<Solver>;
 
-  virtual ~Solver () = default;
+  virtual ~Solver() = default;
 
   /** @brief  Uses a specific solver (IPOPT, SNOPT) to solve the NLP.
     * @param [in/out]  nlp  The nonlinear programming problem.
     */
   virtual void Solve(Problem& nlp) = 0;
 
-
   /** @brief  Get the return status for the optimization. 
     * 
     * e.g. https://coin-or.github.io/Ipopt/OUTPUT.html
     */
-  int GetReturnStatus () const { return status_; };
+  int GetReturnStatus() const { return status_; };
 
-protected:
+ protected:
   int status_;
 };
 

--- a/ifopt_core/include/ifopt/variable_set.h
+++ b/ifopt_core/include/ifopt/variable_set.h
@@ -44,7 +44,7 @@ namespace ifopt {
  * @sa Component
  */
 class VariableSet : public Component {
-public:
+ public:
   /**
    * @brief Creates a set of variables representing a single concept.
    * @param n_var  Number of variables.
@@ -60,8 +60,6 @@ public:
   };
 };
 
-} // namespace ifopt
-
-
+}  // namespace ifopt
 
 #endif /* IFOPT_INCLUDE_IFOPT_VARIABLE_SET_H_ */

--- a/ifopt_core/src/composite.cc
+++ b/ifopt_core/src/composite.cc
@@ -29,79 +29,67 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ifopt/composite.h>
 
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 
 namespace ifopt {
 
-Component::Component (int num_rows, const std::string& name)
+Component::Component(int num_rows, const std::string& name)
 {
   num_rows_ = num_rows;
-  name_ = name;
+  name_     = name;
 }
 
-int
-Component::GetRows () const
+int Component::GetRows() const
 {
   return num_rows_;
 }
 
-void
-Component::SetRows (int num_rows)
+void Component::SetRows(int num_rows)
 {
   num_rows_ = num_rows;
 }
 
-std::string
-Component::GetName () const
+std::string Component::GetName() const
 {
   return name_;
 }
 
-void Component::Print (double tol, int& index) const
+void Component::Print(double tol, int& index) const
 {
   // calculate squared bound violation
-  VectorXd x = GetValues();
+  VectorXd x      = GetValues();
   VecBound bounds = GetBounds();
 
   std::vector<int> viol_idx;
-  for (std::size_t i=0; i<bounds.size(); ++i) {
+  for (std::size_t i = 0; i < bounds.size(); ++i) {
     double lower = bounds.at(i).lower_;
     double upper = bounds.at(i).upper_;
-    double val = x(i);
-    if (val < lower-tol || upper+tol < val)
-      viol_idx.push_back(i); // constraint out of bounds
+    double val   = x(i);
+    if (val < lower - tol || upper + tol < val)
+      viol_idx.push_back(i);  // constraint out of bounds
   }
 
   std::string black = "\033[0m";
   std::string red   = "\033[31m";
-  std::string color = viol_idx.empty()? black : red;
+  std::string color = viol_idx.empty() ? black : red;
 
   std::cout.precision(2);
-  std::cout << std::fixed
-            << std::left
-            << std::setw(30) << name_
-            << std::right
-            << std::setw(4) << num_rows_
-            << std::setw(9) << index
-            << std::setfill ('.')
-            << std::setw(7) << index+num_rows_-1
-            << std::setfill (' ')
-            << color
-            << std::setw(12) << viol_idx.size()
-            << black
-            << std::endl;
+  std::cout << std::fixed << std::left << std::setw(30) << name_ << std::right
+            << std::setw(4) << num_rows_ << std::setw(9) << index
+            << std::setfill('.') << std::setw(7) << index + num_rows_ - 1
+            << std::setfill(' ') << color << std::setw(12) << viol_idx.size()
+            << black << std::endl;
 
   index += num_rows_;
 }
 
-Composite::Composite (const std::string& name, bool is_cost) :Component(0, name)
+Composite::Composite(const std::string& name, bool is_cost) : Component(0, name)
 {
   is_cost_ = is_cost;
 }
 
-void
-Composite::AddComponent (const Component::Ptr& c)
+void Composite::AddComponent(const Component::Ptr& c)
 {
   // at this point the number of rows must be specified.
   assert(c->GetRows() != kSpecifyLater);
@@ -111,29 +99,26 @@ Composite::AddComponent (const Component::Ptr& c)
   if (is_cost_)
     SetRows(1);
   else
-    SetRows(GetRows()+ c->GetRows());
+    SetRows(GetRows() + c->GetRows());
 }
 
-void
-Composite::ClearComponents ()
+void Composite::ClearComponents()
 {
   components_.clear();
   SetRows(0);
 }
 
-const Component::Ptr
-Composite::GetComponent (std::string name) const
+const Component::Ptr Composite::GetComponent(std::string name) const
 {
   for (const auto& c : components_)
     if (c->GetName() == name)
       return c;
 
-  assert(false); // component with name doesn't exist, abort program
+  assert(false);  // component with name doesn't exist, abort program
   return Component::Ptr();
 }
 
-Composite::VectorXd
-Composite::GetValues () const
+Composite::VectorXd Composite::GetValues() const
 {
   VectorXd g_all = VectorXd::Zero(GetRows());
 
@@ -149,38 +134,38 @@ Composite::GetValues () const
   return g_all;
 }
 
-void
-Composite::SetVariables (const VectorXd& x)
+void Composite::SetVariables(const VectorXd& x)
 {
   int row = 0;
   for (auto& c : components_) {
     int n_rows = c->GetRows();
-    c->SetVariables(x.middleRows(row,n_rows));
+    c->SetVariables(x.middleRows(row, n_rows));
     row += n_rows;
   }
 }
 
-Composite::Jacobian
-Composite::GetJacobian () const
-{ // set number of variables only the first time this function is called,
+Composite::Jacobian Composite::GetJacobian() const
+{  // set number of variables only the first time this function is called,
   // since number doesn't change during the optimization. Improves efficiency.
   if (n_var == -1)
     n_var = components_.empty() ? 0 : components_.front()->GetJacobian().cols();
 
   Jacobian jacobian(GetRows(), n_var);
-  
-  if (n_var == 0) return jacobian;
+
+  if (n_var == 0)
+    return jacobian;
 
   int row = 0;
-  std::vector< Eigen::Triplet<double> > triplet_list;
+  std::vector<Eigen::Triplet<double>> triplet_list;
 
   for (const auto& c : components_) {
     const Jacobian& jac = c->GetJacobian();
-    triplet_list.reserve(triplet_list.size()+jac.nonZeros());
+    triplet_list.reserve(triplet_list.size() + jac.nonZeros());
 
-    for (int k=0; k<jac.outerSize(); ++k)
-      for (Jacobian::InnerIterator it(jac,k); it; ++it)
-        triplet_list.push_back(Eigen::Triplet<double>(row+it.row(), it.col(), it.value()));
+    for (int k = 0; k < jac.outerSize(); ++k)
+      for (Jacobian::InnerIterator it(jac, k); it; ++it)
+        triplet_list.push_back(
+            Eigen::Triplet<double>(row + it.row(), it.col(), it.value()));
 
     if (!is_cost_)
       row += c->GetRows();
@@ -190,8 +175,7 @@ Composite::GetJacobian () const
   return jacobian;
 }
 
-Composite::VecBound
-Composite::GetBounds () const
+Composite::VecBound Composite::GetBounds() const
 {
   VecBound bounds_;
   for (const auto& c : components_) {
@@ -202,24 +186,23 @@ Composite::GetBounds () const
   return bounds_;
 }
 
-const Composite::ComponentVec
-Composite::GetComponents () const
+const Composite::ComponentVec Composite::GetComponents() const
 {
   return components_;
 }
 
-void
-Composite::PrintAll () const
+void Composite::PrintAll() const
 {
   int index = 0;
-  double tol = 0.001; ///< tolerance when printing out constraint/bound violation.
+  double tol =
+      0.001;  ///< tolerance when printing out constraint/bound violation.
 
   std::cout << GetName() << ":\n";
   for (auto c : components_) {
-    std::cout << "   "; // indent components
+    std::cout << "   ";  // indent components
     c->Print(tol, index);
   }
   std::cout << std::endl;
 }
 
-} /* namespace opt */
+}  // namespace ifopt

--- a/ifopt_core/src/leaves.cc
+++ b/ifopt_core/src/leaves.cc
@@ -27,34 +27,30 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************************************************************/
 
-#include <ifopt/variable_set.h>
 #include <ifopt/constraint_set.h>
 #include <ifopt/cost_term.h>
+#include <ifopt/variable_set.h>
 
-#include <iostream>
 #include <iomanip>
-
+#include <iostream>
 
 namespace ifopt {
 
 VariableSet::VariableSet(int n_var, const std::string& name)
     : Component(n_var, name)
-{
-}
+{}
 
-ConstraintSet::ConstraintSet (int row_count, const std::string& name)
+ConstraintSet::ConstraintSet(int row_count, const std::string& name)
     : Component(row_count, name)
-{
-}
+{}
 
-ConstraintSet::Jacobian
-ConstraintSet::GetJacobian () const
+ConstraintSet::Jacobian ConstraintSet::GetJacobian() const
 {
   Jacobian jacobian(GetRows(), variables_->GetRows());
 
   int col = 0;
   Jacobian jac;
-  std::vector< Eigen::Triplet<double> > triplet_list;
+  std::vector<Eigen::Triplet<double>> triplet_list;
 
   for (const auto& vars : variables_->GetComponents()) {
     int n = vars->GetRows();
@@ -62,12 +58,13 @@ ConstraintSet::GetJacobian () const
 
     FillJacobianBlock(vars->GetName(), jac);
     // reserve space for the new elements to reduce memory allocation
-    triplet_list.reserve(triplet_list.size()+jac.nonZeros());
+    triplet_list.reserve(triplet_list.size() + jac.nonZeros());
 
     // create triplets for the derivative at the correct position in the overall Jacobian
-    for (int k=0; k<jac.outerSize(); ++k)
-      for (Jacobian::InnerIterator it(jac,k); it; ++it)
-        triplet_list.push_back(Eigen::Triplet<double>(it.row(), col+it.col(), it.value()));
+    for (int k = 0; k < jac.outerSize(); ++k)
+      for (Jacobian::InnerIterator it(jac, k); it; ++it)
+        triplet_list.push_back(
+            Eigen::Triplet<double>(it.row(), col + it.col(), it.value()));
     col += n;
   }
 
@@ -76,49 +73,36 @@ ConstraintSet::GetJacobian () const
   return jacobian;
 }
 
-void
-ConstraintSet::LinkWithVariables(const VariablesPtr& x)
+void ConstraintSet::LinkWithVariables(const VariablesPtr& x)
 {
   variables_ = x;
   InitVariableDependedQuantities(x);
 }
 
-CostTerm::CostTerm (const std::string& name) :ConstraintSet(1, name)
-{
-}
+CostTerm::CostTerm(const std::string& name) : ConstraintSet(1, name) {}
 
-CostTerm::VectorXd
-CostTerm::GetValues() const
+CostTerm::VectorXd CostTerm::GetValues() const
 {
   VectorXd cost(1);
   cost(0) = GetCost();
   return cost;
 }
 
-CostTerm::VecBound
-CostTerm::GetBounds() const
+CostTerm::VecBound CostTerm::GetBounds() const
 {
   return VecBound(GetRows(), NoBound);
 }
 
-void
-CostTerm::Print (double tol, int& index) const
+void CostTerm::Print(double tol, int& index) const
 {
   // only one scalar cost value
   double cost = GetValues()(0);
 
   std::cout.precision(2);
-  std::cout << std::fixed
-            << std::left
-            << std::setw(30) << GetName()
-            << std::right
-            << std::setw(4) << GetRows()
-            << std::setw(9) << index
-            << std::setfill ('.')
-            << std::setw(7) << index+GetRows()-1
-            << std::setfill (' ')
-            << std::setw(12) << cost
-            << std::endl;
+  std::cout << std::fixed << std::left << std::setw(30) << GetName()
+            << std::right << std::setw(4) << GetRows() << std::setw(9) << index
+            << std::setfill('.') << std::setw(7) << index + GetRows() - 1
+            << std::setfill(' ') << std::setw(12) << cost << std::endl;
 }
 
-} /* namespace opt */
+}  // namespace ifopt

--- a/ifopt_core/src/problem.cc
+++ b/ifopt_core/src/problem.cc
@@ -28,65 +28,55 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************************************************************/
 
 #include <ifopt/problem.h>
-#include <iostream>
 #include <iomanip>
-
+#include <iostream>
 
 namespace ifopt {
 
-Problem::Problem ()
-    :constraints_("constraint-sets", false),
-     costs_("cost-terms", true)
+Problem::Problem()
+    : constraints_("constraint-sets", false), costs_("cost-terms", true)
 {
   variables_ = std::make_shared<Composite>("variable-sets", false);
 }
 
-void
-Problem::AddVariableSet(VariableSet::Ptr variable_set)
+void Problem::AddVariableSet(VariableSet::Ptr variable_set)
 {
   variables_->AddComponent(variable_set);
 }
 
-void
-Problem::AddConstraintSet(ConstraintSet::Ptr constraint_set)
+void Problem::AddConstraintSet(ConstraintSet::Ptr constraint_set)
 {
   constraint_set->LinkWithVariables(variables_);
   constraints_.AddComponent(constraint_set);
 }
 
-void
-Problem::AddCostSet(CostTerm::Ptr cost_set)
+void Problem::AddCostSet(CostTerm::Ptr cost_set)
 {
   cost_set->LinkWithVariables(variables_);
   costs_.AddComponent(cost_set);
 }
 
-int
-Problem::GetNumberOfOptimizationVariables () const
+int Problem::GetNumberOfOptimizationVariables() const
 {
   return variables_->GetRows();
 }
 
-Problem::VecBound
-Problem::GetBoundsOnOptimizationVariables () const
+Problem::VecBound Problem::GetBoundsOnOptimizationVariables() const
 {
   return variables_->GetBounds();
 }
 
-Problem::VectorXd
-Problem::GetVariableValues () const
+Problem::VectorXd Problem::GetVariableValues() const
 {
   return variables_->GetValues();
 }
 
-void
-Problem::SetVariables (const double* x)
+void Problem::SetVariables(const double* x)
 {
   variables_->SetVariables(ConvertToEigen(x));
 }
 
-double
-Problem::EvaluateCostFunction (const double* x)
+double Problem::EvaluateCostFunction(const double* x)
 {
   VectorXd g = VectorXd::Zero(1);
   if (HasCostTerms()) {
@@ -96,23 +86,23 @@ Problem::EvaluateCostFunction (const double* x)
   return g(0);
 }
 
-Problem::VectorXd
-Problem::EvaluateCostFunctionGradient (const double* x, bool use_finite_difference_approximation, double epsilon)
+Problem::VectorXd Problem::EvaluateCostFunctionGradient(
+    const double* x, bool use_finite_difference_approximation, double epsilon)
 {
-  int n = GetNumberOfOptimizationVariables();
-  Jacobian jac = Jacobian(1,n);
+  int n        = GetNumberOfOptimizationVariables();
+  Jacobian jac = Jacobian(1, n);
   if (HasCostTerms()) {
-    if(use_finite_difference_approximation) {
+    if (use_finite_difference_approximation) {
       double step_size = epsilon;
-      
+
       // calculate forward difference by disturbing each optimization variable
       double g = EvaluateCostFunction(x);
       std::vector<double> x_new(x, x + n);
-      for (int i=0; i<n; ++i) {
-        x_new[i] += step_size; // disturb
-        double g_new = EvaluateCostFunction(x_new.data());
-        jac.coeffRef(0,i) = (g_new - g)/step_size;
-        x_new[i] = x[i]; // reset for next iteration
+      for (int i = 0; i < n; ++i) {
+        x_new[i] += step_size;  // disturb
+        double g_new       = EvaluateCostFunction(x_new.data());
+        jac.coeffRef(0, i) = (g_new - g) / step_size;
+        x_new[i]           = x[i];  // reset for next iteration
       }
     } else {
       SetVariables(x);
@@ -123,79 +113,67 @@ Problem::EvaluateCostFunctionGradient (const double* x, bool use_finite_differen
   return jac.row(0).transpose();
 }
 
-Problem::VecBound
-Problem::GetBoundsOnConstraints () const
+Problem::VecBound Problem::GetBoundsOnConstraints() const
 {
   return constraints_.GetBounds();
 }
 
-int
-Problem::GetNumberOfConstraints () const
+int Problem::GetNumberOfConstraints() const
 {
   return GetBoundsOnConstraints().size();
 }
 
-Problem::VectorXd
-Problem::EvaluateConstraints (const double* x)
+Problem::VectorXd Problem::EvaluateConstraints(const double* x)
 {
   SetVariables(x);
   return constraints_.GetValues();
 }
 
-bool
-Problem::HasCostTerms () const
+bool Problem::HasCostTerms() const
 {
-  return costs_.GetRows()>0;
+  return costs_.GetRows() > 0;
 }
 
-void
-Problem::EvalNonzerosOfJacobian (const double* x, double* values)
+void Problem::EvalNonzerosOfJacobian(const double* x, double* values)
 {
   SetVariables(x);
   Jacobian jac = GetJacobianOfConstraints();
 
-  jac.makeCompressed(); // so the valuePtr() is dense and accurate
+  jac.makeCompressed();  // so the valuePtr() is dense and accurate
   std::copy(jac.valuePtr(), jac.valuePtr() + jac.nonZeros(), values);
 }
 
-Problem::Jacobian
-Problem::GetJacobianOfConstraints () const
+Problem::Jacobian Problem::GetJacobianOfConstraints() const
 {
   return constraints_.GetJacobian();
 }
 
-Problem::Jacobian
-Problem::GetJacobianOfCosts () const
+Problem::Jacobian Problem::GetJacobianOfCosts() const
 {
   return costs_.GetJacobian();
 }
 
-void
-Problem::SaveCurrent()
+void Problem::SaveCurrent()
 {
   x_prev.push_back(variables_->GetValues());
 }
 
-Composite::Ptr
-Problem::GetOptVariables () const
+Composite::Ptr Problem::GetOptVariables() const
 {
   return variables_;
 }
 
-void
-Problem::SetOptVariables (int iter)
+void Problem::SetOptVariables(int iter)
 {
   variables_->SetVariables(x_prev.at(iter));
 }
 
-void
-Problem::SetOptVariablesFinal ()
+void Problem::SetOptVariablesFinal()
 {
-  variables_->SetVariables(x_prev.at(GetIterationCount()-1));
+  variables_->SetVariables(x_prev.at(GetIterationCount() - 1));
 }
 
-void
-Problem::PrintCurrent() const
+void Problem::PrintCurrent() const
 {
   using namespace std;
   cout << "\n"
@@ -208,14 +186,11 @@ Problem::PrintCurrent() const
        << "Legend:\n"
        << "c - number of variables, constraints or cost terms" << std::endl
        << "i - indices of this set in overall problem" << std::endl
-       << "v - number of [violated variable- or constraint-bounds] or [cost term value]"
+       << "v - number of [violated variable- or constraint-bounds] or [cost "
+          "term value]"
        << "\n\n"
-       << std::right
-       << std::setw(33) << ""
-       << std::setw(5)  << "c  "
-       << std::setw(16) << "i    "
-       << std::setw(11) << "v "
-       << std::left
+       << std::right << std::setw(33) << "" << std::setw(5) << "c  "
+       << std::setw(16) << "i    " << std::setw(11) << "v " << std::left
        << "\n";
 
   variables_->PrintAll();
@@ -223,11 +198,9 @@ Problem::PrintCurrent() const
   costs_.PrintAll();
 };
 
-Problem::VectorXd
-Problem::ConvertToEigen(const double* x) const
+Problem::VectorXd Problem::ConvertToEigen(const double* x) const
 {
-  return Eigen::Map<const VectorXd>(x,GetNumberOfOptimizationVariables());
+  return Eigen::Map<const VectorXd>(x, GetNumberOfOptimizationVariables());
 }
 
-} /* namespace opt */
-
+}  // namespace ifopt

--- a/ifopt_core/test/composite_test.cc
+++ b/ifopt_core/test/composite_test.cc
@@ -30,21 +30,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 #include <ifopt/composite.h>
 
-
 namespace ifopt {
 
 class ExComponent : public Component {
-public:
-  ExComponent(int n_var, const std::string& name) : Component(n_var, name) {};
+ public:
+  ExComponent(int n_var, const std::string& name) : Component(n_var, name){};
 
-  virtual VectorXd GetValues()   const { throw std::runtime_error("not implemented");};
-  virtual VecBound GetBounds()   const { throw std::runtime_error("not implemented");};
-  virtual Jacobian GetJacobian() const { throw std::runtime_error("not implemented");};
-  virtual void SetVariables(const VectorXd& x) {};
+  virtual VectorXd GetValues() const
+  {
+    throw std::runtime_error("not implemented");
+  };
+  virtual VecBound GetBounds() const
+  {
+    throw std::runtime_error("not implemented");
+  };
+  virtual Jacobian GetJacobian() const
+  {
+    throw std::runtime_error("not implemented");
+  };
+  virtual void SetVariables(const VectorXd& x){};
 };
 
-} // namespace opt
-
+}  // namespace ifopt
 
 using namespace ifopt;
 
@@ -57,13 +64,11 @@ TEST(Component, GetRows)
   EXPECT_EQ(4, c.GetRows());
 }
 
-
 TEST(Component, GetName)
 {
   ExComponent c(2, "ex_component");
   EXPECT_STREQ("ex_component", c.GetName().c_str());
 }
-
 
 TEST(Composite, GetRowsCost)
 {
@@ -78,7 +83,6 @@ TEST(Composite, GetRowsCost)
   EXPECT_EQ(1, cost.GetRows());
 }
 
-
 TEST(Composite, GetRowsConstraint)
 {
   auto c1 = std::make_shared<ExComponent>(0, "component1");
@@ -89,9 +93,8 @@ TEST(Composite, GetRowsConstraint)
   constraint.AddComponent(c1);
   constraint.AddComponent(c2);
   constraint.AddComponent(c3);
-  EXPECT_EQ(0+1+2, constraint.GetRows());
+  EXPECT_EQ(0 + 1 + 2, constraint.GetRows());
 }
-
 
 TEST(Composite, GetComponent)
 {
@@ -114,7 +117,6 @@ TEST(Composite, GetComponent)
   EXPECT_NE(c1->GetRows(), c3_new->GetRows());
 }
 
-
 TEST(Composite, ClearComponents)
 {
   auto c1 = std::make_shared<ExComponent>(0, "component1");
@@ -126,7 +128,7 @@ TEST(Composite, ClearComponents)
   comp.AddComponent(c2);
   comp.AddComponent(c3);
 
-  EXPECT_EQ(0+1+2, comp.GetRows());
+  EXPECT_EQ(0 + 1 + 2, comp.GetRows());
 
   comp.ClearComponents();
   EXPECT_EQ(0, comp.GetRows());

--- a/ifopt_core/test/ifopt/test_vars_constr_cost.h
+++ b/ifopt_core/test/ifopt/test_vars_constr_cost.h
@@ -51,19 +51,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * http://docs.ros.org/api/ifopt/html/group__ProblemFormulation.html
  */
 
-#include <ifopt/variable_set.h>
 #include <ifopt/constraint_set.h>
 #include <ifopt/cost_term.h>
+#include <ifopt/variable_set.h>
 
 namespace ifopt {
 using Eigen::Vector2d;
 
-
 class ExVariables : public VariableSet {
-public:
+ public:
   // Every variable set has a name, here "var_set1". this allows the constraints
   // and costs to define values and Jacobians specifically w.r.t this variable set.
-  ExVariables() : ExVariables("var_set1") {};
+  ExVariables() : ExVariables("var_set1"){};
   ExVariables(const std::string& name) : VariableSet(2, name)
   {
     // the initial values where the NLP starts iterating from
@@ -82,10 +81,7 @@ public:
 
   // Here is the reverse transformation from the internal representation to
   // to the Eigen::Vector
-  VectorXd GetValues() const override
-  {
-    return Vector2d(x0_, x1_);
-  };
+  VectorXd GetValues() const override { return Vector2d(x0_, x1_); };
 
   // Each variable has an upper and lower bound set here
   VecBound GetBounds() const override
@@ -96,13 +92,12 @@ public:
     return bounds;
   }
 
-private:
+ private:
   double x0_, x1_;
 };
 
-
 class ExConstraint : public ConstraintSet {
-public:
+ public:
   ExConstraint() : ExConstraint("constraint1") {}
 
   // This constraint set just contains 1 constraint, however generally
@@ -114,7 +109,7 @@ public:
   {
     VectorXd g(GetRows());
     Vector2d x = GetVariables()->GetComponent("var_set1")->GetValues();
-    g(0) = std::pow(x(0),2) + x(1);
+    g(0)       = std::pow(x(0), 2) + x(1);
     return g;
   };
 
@@ -133,7 +128,8 @@ public:
   // approximate the derivatives by finite differences and not overwrite this
   // function, e.g. in ipopt.cc::use_jacobian_approximation_ = true
   // Attention: see the parent class function for important information on sparsity pattern.
-  void FillJacobianBlock (std::string var_set, Jacobian& jac_block) const override
+  void FillJacobianBlock(std::string var_set,
+                         Jacobian& jac_block) const override
   {
     // must fill only that submatrix of the overall Jacobian that relates
     // to this constraint and "var_set1". even if more constraints or variables
@@ -142,34 +138,34 @@ public:
     if (var_set == "var_set1") {
       Vector2d x = GetVariables()->GetComponent("var_set1")->GetValues();
 
-      jac_block.coeffRef(0, 0) = 2.0*x(0); // derivative of first constraint w.r.t x0
-      jac_block.coeffRef(0, 1) = 1.0;      // derivative of first constraint w.r.t x1
+      jac_block.coeffRef(0, 0) =
+          2.0 * x(0);  // derivative of first constraint w.r.t x0
+      jac_block.coeffRef(0, 1) =
+          1.0;  // derivative of first constraint w.r.t x1
     }
   }
 };
 
-
-class ExCost: public CostTerm {
-public:
+class ExCost : public CostTerm {
+ public:
   ExCost() : ExCost("cost_term1") {}
   ExCost(const std::string& name) : CostTerm(name) {}
 
   double GetCost() const override
   {
     Vector2d x = GetVariables()->GetComponent("var_set1")->GetValues();
-    return -std::pow(x(1)-2,2);
+    return -std::pow(x(1) - 2, 2);
   };
 
-  void FillJacobianBlock (std::string var_set, Jacobian& jac) const override
+  void FillJacobianBlock(std::string var_set, Jacobian& jac) const override
   {
     if (var_set == "var_set1") {
       Vector2d x = GetVariables()->GetComponent("var_set1")->GetValues();
 
-      jac.coeffRef(0, 0) = 0.0;             // derivative of cost w.r.t x0
-      jac.coeffRef(0, 1) = -2.0*(x(1)-2.0); // derivative of cost w.r.t x1
+      jac.coeffRef(0, 0) = 0.0;                  // derivative of cost w.r.t x0
+      jac.coeffRef(0, 1) = -2.0 * (x(1) - 2.0);  // derivative of cost w.r.t x1
     }
   }
 };
 
-} // namespace opt
-
+}  // namespace ifopt

--- a/ifopt_core/test/problem_test.cc
+++ b/ifopt_core/test/problem_test.cc
@@ -40,9 +40,8 @@ TEST(Problem, GetNumberOfOptimizationVariables)
   nlp.AddVariableSet(std::make_shared<ExVariables>("var_set0"));
   nlp.AddVariableSet(std::make_shared<ExVariables>("var_set1"));
 
-  EXPECT_EQ(2+2, nlp.GetNumberOfOptimizationVariables());
+  EXPECT_EQ(2 + 2, nlp.GetNumberOfOptimizationVariables());
 }
-
 
 TEST(Problem, GetBoundsOnOptimizationVariables)
 {
@@ -51,7 +50,7 @@ TEST(Problem, GetBoundsOnOptimizationVariables)
   nlp.AddVariableSet(std::make_shared<ExVariables>("var_set1"));
 
   auto bounds = nlp.GetBoundsOnOptimizationVariables();
-  EXPECT_EQ(2+2, bounds.size());
+  EXPECT_EQ(2 + 2, bounds.size());
 
   // var_set0
   EXPECT_DOUBLE_EQ(-1.0, bounds.at(0).lower_);
@@ -65,7 +64,6 @@ TEST(Problem, GetBoundsOnOptimizationVariables)
   EXPECT_DOUBLE_EQ(-inf, bounds.at(3).lower_);
   EXPECT_DOUBLE_EQ(+inf, bounds.at(3).upper_);
 }
-
 
 TEST(Problem, GetVariableValues)
 {
@@ -86,7 +84,6 @@ TEST(Problem, GetVariableValues)
   EXPECT_EQ(0.4, x(3));
 }
 
-
 TEST(Problem, GetNumberOfConstraints)
 {
   Problem nlp;
@@ -97,9 +94,8 @@ TEST(Problem, GetNumberOfConstraints)
   //same - the full Jacobian is stitched together accordingly.
   nlp.AddConstraintSet(std::make_shared<ExConstraint>("constraint2"));
 
-  EXPECT_EQ(1+1, nlp.GetNumberOfConstraints());
+  EXPECT_EQ(1 + 1, nlp.GetNumberOfConstraints());
 }
-
 
 TEST(Problem, GetBoundsOnConstraints)
 {
@@ -115,7 +111,6 @@ TEST(Problem, GetBoundsOnConstraints)
   EXPECT_DOUBLE_EQ(1.0, bounds.at(1).upper_);
 }
 
-
 TEST(Problem, EvaluateConstraints)
 {
   Problem nlp;
@@ -123,12 +118,11 @@ TEST(Problem, EvaluateConstraints)
   nlp.AddConstraintSet(std::make_shared<ExConstraint>("constraint1"));
   nlp.AddConstraintSet(std::make_shared<ExConstraint>("constraint2"));
 
-  double x[2] = { 2.0, 3.0 };
+  double x[2]       = {2.0, 3.0};
   Eigen::VectorXd g = nlp.EvaluateConstraints(x);
-  EXPECT_DOUBLE_EQ(2*2.0+3.0, g(0)); // constant -1 moved to bounds
-  EXPECT_DOUBLE_EQ(2*2.0+3.0, g(1)); // constant -1 moved to bounds
+  EXPECT_DOUBLE_EQ(2 * 2.0 + 3.0, g(0));  // constant -1 moved to bounds
+  EXPECT_DOUBLE_EQ(2 * 2.0 + 3.0, g(1));  // constant -1 moved to bounds
 }
-
 
 TEST(Problem, GetJacobianOfConstraints)
 {
@@ -137,18 +131,17 @@ TEST(Problem, GetJacobianOfConstraints)
   nlp.AddConstraintSet(std::make_shared<ExConstraint>("constraint1"));
   nlp.AddConstraintSet(std::make_shared<ExConstraint>("constraint2"));
 
-  double x[2] = { 2.0, 3.0 };
+  double x[2] = {2.0, 3.0};
   nlp.SetVariables(x);
   auto jac = nlp.GetJacobianOfConstraints();
   EXPECT_EQ(nlp.GetNumberOfConstraints(), jac.rows());
   EXPECT_EQ(nlp.GetNumberOfOptimizationVariables(), jac.cols());
 
-  EXPECT_DOUBLE_EQ(2*x[0], jac.coeffRef(0,0)); // constraint 1 w.r.t x0
-  EXPECT_DOUBLE_EQ(1.0,    jac.coeffRef(0,1)); // constraint 1 w.r.t x1
-  EXPECT_DOUBLE_EQ(2*x[0], jac.coeffRef(1,0)); // constraint 2 w.r.t x0
-  EXPECT_DOUBLE_EQ(1.0,    jac.coeffRef(1,1)); // constraint 2 w.r.t x1
+  EXPECT_DOUBLE_EQ(2 * x[0], jac.coeffRef(0, 0));  // constraint 1 w.r.t x0
+  EXPECT_DOUBLE_EQ(1.0, jac.coeffRef(0, 1));       // constraint 1 w.r.t x1
+  EXPECT_DOUBLE_EQ(2 * x[0], jac.coeffRef(1, 0));  // constraint 2 w.r.t x0
+  EXPECT_DOUBLE_EQ(1.0, jac.coeffRef(1, 1));       // constraint 2 w.r.t x1
 }
-
 
 TEST(Problem, EvaluateCostFunction)
 {
@@ -159,10 +152,10 @@ TEST(Problem, EvaluateCostFunction)
 
   EXPECT_TRUE(nlp.HasCostTerms());
 
-  double x[2] = { 2.0, 3.0 };
-  EXPECT_DOUBLE_EQ(2*(-std::pow(x[1]-2.0,2)), nlp.EvaluateCostFunction(x)); // constant -1 moved to bounds
+  double x[2] = {2.0, 3.0};
+  EXPECT_DOUBLE_EQ(2 * (-std::pow(x[1] - 2.0, 2)),
+                   nlp.EvaluateCostFunction(x));  // constant -1 moved to bounds
 }
-
 
 TEST(Problem, HasCostTerms)
 {
@@ -179,7 +172,6 @@ TEST(Problem, HasCostTerms)
   EXPECT_TRUE(nlp.HasCostTerms());
 }
 
-
 TEST(Problem, EvaluateCostFunctionGradient)
 {
   Problem nlp;
@@ -187,12 +179,10 @@ TEST(Problem, EvaluateCostFunctionGradient)
   nlp.AddCostSet(std::make_shared<ExCost>("cost_term1"));
   nlp.AddCostSet(std::make_shared<ExCost>("cost_term2"));
 
-  double x[2] = { 2.0, 3.0 };
+  double x[2]          = {2.0, 3.0};
   Eigen::VectorXd grad = nlp.EvaluateCostFunctionGradient(x);
 
   EXPECT_EQ(nlp.GetNumberOfOptimizationVariables(), grad.rows());
-  EXPECT_DOUBLE_EQ(0.0,             grad(0)); // cost1+cost2 w.r.t x0
-  EXPECT_DOUBLE_EQ(2*(-2*(x[1]-2)), grad(1)); // cost1+cost2 w.r.t x1
+  EXPECT_DOUBLE_EQ(0.0, grad(0));                    // cost1+cost2 w.r.t x0
+  EXPECT_DOUBLE_EQ(2 * (-2 * (x[1] - 2)), grad(1));  // cost1+cost2 w.r.t x1
 }
-
-

--- a/ifopt_ipopt/include/ifopt/ipopt_adapter.h
+++ b/ifopt_ipopt/include/ifopt/ipopt_adapter.h
@@ -27,9 +27,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef IFOPT_INCLUDE_OPT_IPOPT_ADAPTER_H_
 #define IFOPT_INCLUDE_OPT_IPOPT_ADAPTER_H_
 
-#include <IpTNLP.hpp>
 #include <IpIpoptApplication.hpp>
 #include <IpSolveStatistics.hpp>
+#include <IpTNLP.hpp>
 
 #include <ifopt/problem.h>
 
@@ -52,7 +52,7 @@ namespace Ipopt {
  * functionality, but merely delegate it to the Adaptee (the Problem object).
  */
 class IpoptAdapter : public TNLP {
-public:
+ public:
   using Problem  = ifopt::Problem;
   using VectorXd = Problem::VectorXd;
   using Jacobian = Problem::Jacobian;
@@ -66,29 +66,30 @@ public:
   IpoptAdapter(Problem& nlp, bool finite_diff = false);
   virtual ~IpoptAdapter() = default;
 
-private:
-  Problem* nlp_; ///< The solver independent problem definition
-  bool finite_diff_;  ///< Flag that indicates the "finite-difference-values" option is set
+ private:
+  Problem* nlp_;  ///< The solver independent problem definition
+  bool
+      finite_diff_;  ///< Flag that indicates the "finite-difference-values" option is set
 
   /** Method to return some info about the nlp */
   virtual bool get_nlp_info(Index& n, Index& m, Index& nnz_jac_g,
                             Index& nnz_h_lag, IndexStyleEnum& index_style);
 
   /** Method to return the bounds for my problem */
-  virtual bool get_bounds_info(Index n, double* x_l, double* x_u,
-                               Index m, double* g_l, double* g_u);
+  virtual bool get_bounds_info(Index n, double* x_l, double* x_u, Index m,
+                               double* g_l, double* g_u);
 
   /** Method to return the starting point for the algorithm */
-  virtual bool get_starting_point(Index n, bool init_x, double* x,
-                                  bool init_z, double* z_L, double* z_U,
-                                  Index m, bool init_lambda,
-                                  double* lambda);
+  virtual bool get_starting_point(Index n, bool init_x, double* x, bool init_z,
+                                  double* z_L, double* z_U, Index m,
+                                  bool init_lambda, double* lambda);
 
   /** Method to return the objective value */
   virtual bool eval_f(Index n, const double* x, bool new_x, double& obj_value);
 
   /** Method to return the gradient of the objective */
-  virtual bool eval_grad_f(Index n, const double* x, bool new_x, double* grad_f);
+  virtual bool eval_grad_f(Index n, const double* x, bool new_x,
+                           double* grad_f);
 
   /** Method to return the constraint residuals */
   virtual bool eval_g(Index n, const double* x, bool new_x, Index m, double* g);
@@ -97,32 +98,29 @@ private:
    *   1) The structure of the jacobian (if "values" is NULL)
    *   2) The values of the jacobian (if "values" is not NULL)
    */
-  virtual bool eval_jac_g(Index n, const double* x, bool new_x,
-                          Index m, Index nele_jac, Index* iRow, Index *jCol,
+  virtual bool eval_jac_g(Index n, const double* x, bool new_x, Index m,
+                          Index nele_jac, Index* iRow, Index* jCol,
                           double* values);
 
   /** This is called after every iteration and is used to save intermediate
     *  solutions in the nlp */
-  virtual bool intermediate_callback(AlgorithmMode mode,
-                                     Index iter, double obj_value,
-                                     double inf_pr, double inf_du,
-                                     double mu, double d_norm,
+  virtual bool intermediate_callback(AlgorithmMode mode, Index iter,
+                                     double obj_value, double inf_pr,
+                                     double inf_du, double mu, double d_norm,
                                      double regularization_size,
                                      double alpha_du, double alpha_pr,
-                                     Index ls_trials,
-                                     const IpoptData* ip_data,
+                                     Index ls_trials, const IpoptData* ip_data,
                                      IpoptCalculatedQuantities* ip_cq);
 
   /** This method is called when the algorithm is complete so the TNLP can
     * store/write the solution */
-  virtual void finalize_solution(SolverReturn status,
-                                 Index n, const double* x, const double* z_L, const double* z_U,
-                                 Index m, const double* g, const double* lambda,
-                                 double obj_value,
-                                 const IpoptData* ip_data,
+  virtual void finalize_solution(SolverReturn status, Index n, const double* x,
+                                 const double* z_L, const double* z_U, Index m,
+                                 const double* g, const double* lambda,
+                                 double obj_value, const IpoptData* ip_data,
                                  IpoptCalculatedQuantities* ip_cq);
 };
 
-} // namespace Ipopt
+}  // namespace Ipopt
 
 #endif /* IFOPT_INCLUDE_OPT_IPOPT_ADAPTER_H_ */

--- a/ifopt_ipopt/include/ifopt/ipopt_solver.h
+++ b/ifopt_ipopt/include/ifopt/ipopt_solver.h
@@ -30,7 +30,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ifopt/problem.h>
 #include <ifopt/solver.h>
 
-
 namespace Ipopt {
 class IpoptApplication;
 }
@@ -46,7 +45,7 @@ namespace ifopt {
  * @ingroup Solvers
  */
 class IpoptSolver : public Solver {
-public:
+ public:
   using Ptr = std::shared_ptr<IpoptSolver>;
 
   IpoptSolver(bool rethrow_non_ipopt_exceptions = false);
@@ -66,9 +65,9 @@ public:
 
   /** @brief  Get the total wall clock time for the optimization, including function evaluations.
     */
-  double GetTotalWallclockTime ();
+  double GetTotalWallclockTime();
 
-private:
+ private:
   std::shared_ptr<Ipopt::IpoptApplication> ipopt_app_;
 };
 

--- a/ifopt_ipopt/src/ipopt_adapter.cc
+++ b/ifopt_ipopt/src/ipopt_adapter.cc
@@ -30,7 +30,7 @@ namespace Ipopt {
 
 IpoptAdapter::IpoptAdapter(Problem& nlp, bool finite_diff)
 {
-  nlp_ = &nlp;
+  nlp_         = &nlp;
   finite_diff_ = finite_diff;
 }
 
@@ -41,11 +41,11 @@ bool IpoptAdapter::get_nlp_info(Index& n, Index& m, Index& nnz_jac_g,
   m = nlp_->GetNumberOfConstraints();
 
   if (finite_diff_)
-    nnz_jac_g = m*n;
+    nnz_jac_g = m * n;
   else
     nnz_jac_g = nlp_->GetJacobianOfConstraints().nonZeros();
 
-  nnz_h_lag = n*n;
+  nnz_h_lag = n * n;
 
   // start index at 0 for row/col entries
   index_style = C_STYLE;
@@ -57,14 +57,14 @@ bool IpoptAdapter::get_bounds_info(Index n, double* x_lower, double* x_upper,
                                    Index m, double* g_l, double* g_u)
 {
   auto bounds_x = nlp_->GetBoundsOnOptimizationVariables();
-  for (std::size_t c=0; c<bounds_x.size(); ++c) {
+  for (std::size_t c = 0; c < bounds_x.size(); ++c) {
     x_lower[c] = bounds_x.at(c).lower_;
     x_upper[c] = bounds_x.at(c).upper_;
   }
 
   // specific bounds depending on equality and inequality constraints
   auto bounds_g = nlp_->GetBoundsOnConstraints();
-  for (std::size_t c=0; c<bounds_g.size(); ++c) {
+  for (std::size_t c = 0; c < bounds_g.size(); ++c) {
     g_l[c] = bounds_g.at(c).lower_;
     g_u[c] = bounds_g.at(c).upper_;
   }
@@ -74,71 +74,72 @@ bool IpoptAdapter::get_bounds_info(Index n, double* x_lower, double* x_upper,
 
 bool IpoptAdapter::get_starting_point(Index n, bool init_x, double* x,
                                       bool init_z, double* z_L, double* z_U,
-                                      Index m, bool init_lambda,
-                                      double* lambda)
+                                      Index m, bool init_lambda, double* lambda)
 {
   // Here, we assume we only have starting values for x
   assert(init_x == true);
   assert(init_z == false);
   assert(init_lambda == false);
 
-  VectorXd x_all = nlp_->GetVariableValues();
+  VectorXd x_all                            = nlp_->GetVariableValues();
   Eigen::Map<VectorXd>(&x[0], x_all.rows()) = x_all;
 
   return true;
 }
 
-bool IpoptAdapter::eval_f(Index n, const double* x, bool new_x, double& obj_value)
+bool IpoptAdapter::eval_f(Index n, const double* x, bool new_x,
+                          double& obj_value)
 {
   obj_value = nlp_->EvaluateCostFunction(x);
   return true;
 }
 
-bool IpoptAdapter::eval_grad_f(Index n, const double* x, bool new_x, double* grad_f)
+bool IpoptAdapter::eval_grad_f(Index n, const double* x, bool new_x,
+                               double* grad_f)
 {
   Eigen::VectorXd grad = nlp_->EvaluateCostFunctionGradient(x, finite_diff_);
-  Eigen::Map<Eigen::MatrixXd>(grad_f,n,1) = grad;
+  Eigen::Map<Eigen::MatrixXd>(grad_f, n, 1) = grad;
   return true;
 }
 
-bool IpoptAdapter::eval_g(Index n, const double* x, bool new_x, Index m, double* g)
+bool IpoptAdapter::eval_g(Index n, const double* x, bool new_x, Index m,
+                          double* g)
 {
-  VectorXd g_eig = nlp_->EvaluateConstraints(x);
-  Eigen::Map<VectorXd>(g,m) = g_eig;
+  VectorXd g_eig             = nlp_->EvaluateConstraints(x);
+  Eigen::Map<VectorXd>(g, m) = g_eig;
   return true;
 }
 
-bool IpoptAdapter::eval_jac_g(Index n, const double* x, bool new_x,
-                              Index m, Index nele_jac, Index* iRow, Index *jCol,
+bool IpoptAdapter::eval_jac_g(Index n, const double* x, bool new_x, Index m,
+                              Index nele_jac, Index* iRow, Index* jCol,
                               double* values)
 {
   // defines the positions of the nonzero elements of the jacobian
   if (values == NULL) {
-	// If "jacobian_approximation" option is set as "finite-difference-values", the Jacobian is dense!
-	Index nele=0;
-	if (finite_diff_) { // dense jacobian
-	  for (Index row = 0; row < m; row++) {
-	    for (Index col = 0; col < n; col++) {
-	      iRow[nele] = row;
-	      jCol[nele] = col;
-	      nele++;
-	    }
-	  }
-	}
-	else {	// sparse jacobian
-	  auto jac = nlp_->GetJacobianOfConstraints();
-	  for (int k=0; k<jac.outerSize(); ++k) {
-	    for (Jacobian::InnerIterator it(jac,k); it; ++it) {
-	      iRow[nele] = it.row();
-	      jCol[nele] = it.col();
-	      nele++;
-	    }
-	  }
-	}
+    // If "jacobian_approximation" option is set as "finite-difference-values", the Jacobian is dense!
+    Index nele = 0;
+    if (finite_diff_) {  // dense jacobian
+      for (Index row = 0; row < m; row++) {
+        for (Index col = 0; col < n; col++) {
+          iRow[nele] = row;
+          jCol[nele] = col;
+          nele++;
+        }
+      }
+    } else {  // sparse jacobian
+      auto jac = nlp_->GetJacobianOfConstraints();
+      for (int k = 0; k < jac.outerSize(); ++k) {
+        for (Jacobian::InnerIterator it(jac, k); it; ++it) {
+          iRow[nele] = it.row();
+          jCol[nele] = it.col();
+          nele++;
+        }
+      }
+    }
 
-    assert(nele == nele_jac); // initial sparsity structure is never allowed to change
-  }
-  else {
+    assert(nele ==
+           nele_jac);  // initial sparsity structure is never allowed to change
+  } else {
     // only gets used if "jacobian_approximation finite-difference-values" is not set
     nlp_->EvalNonzerosOfJacobian(x, values);
   }
@@ -146,29 +147,25 @@ bool IpoptAdapter::eval_jac_g(Index n, const double* x, bool new_x,
   return true;
 }
 
-bool IpoptAdapter::intermediate_callback(AlgorithmMode mode,
-                                         Index iter, double obj_value,
-                                         double inf_pr, double inf_du,
-                                         double mu, double d_norm,
-                                         double regularization_size,
-                                         double alpha_du, double alpha_pr,
-                                         Index ls_trials,
-                                         const IpoptData* ip_data,
-                                         IpoptCalculatedQuantities* ip_cq)
+bool IpoptAdapter::intermediate_callback(
+    AlgorithmMode mode, Index iter, double obj_value, double inf_pr,
+    double inf_du, double mu, double d_norm, double regularization_size,
+    double alpha_du, double alpha_pr, Index ls_trials, const IpoptData* ip_data,
+    IpoptCalculatedQuantities* ip_cq)
 {
   nlp_->SaveCurrent();
   return true;
 }
 
-void IpoptAdapter::finalize_solution(SolverReturn status,
-                                     Index n, const double* x, const double* z_L, const double* z_U,
-                                     Index m, const double* g, const double* lambda,
-                                     double obj_value,
-                                     const IpoptData* ip_data,
+void IpoptAdapter::finalize_solution(SolverReturn status, Index n,
+                                     const double* x, const double* z_L,
+                                     const double* z_U, Index m,
+                                     const double* g, const double* lambda,
+                                     double obj_value, const IpoptData* ip_data,
                                      IpoptCalculatedQuantities* ip_cq)
 {
   nlp_->SetVariables(x);
   nlp_->SaveCurrent();
 }
 
-} // namespace Ipopt
+}  // namespace Ipopt

--- a/ifopt_ipopt/src/ipopt_solver.cc
+++ b/ifopt_ipopt/src/ipopt_solver.cc
@@ -24,15 +24,15 @@ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************************************************************/
 
-#include <ifopt/ipopt_solver.h>
 #include <ifopt/ipopt_adapter.h>
+#include <ifopt/ipopt_solver.h>
 
 namespace ifopt {
 
 IpoptSolver::IpoptSolver(bool rethrow_non_ipopt_exceptions)
 {
   ipopt_app_ = std::make_shared<Ipopt::IpoptApplication>();
-  status_ = Ipopt::Solve_Succeeded;
+  status_    = Ipopt::Solve_Succeeded;
 
   /* Which linear solver to use. Mumps is default because it comes with the
    * precompiled ubuntu binaries. However, the coin-hsl solvers can be
@@ -63,52 +63,50 @@ IpoptSolver::IpoptSolver(bool rethrow_non_ipopt_exceptions)
   ipopt_app_->RethrowNonIpoptException(rethrow_non_ipopt_exceptions);
 }
 
-void
-IpoptSolver::Solve (Problem& nlp)
+void IpoptSolver::Solve(Problem& nlp)
 {
   using namespace Ipopt;
 
   status_ = ipopt_app_->Initialize();
   if (status_ != Solve_Succeeded) {
-    std::cout << std::endl << std::endl << "*** Error during initialization!" << std::endl;
+    std::cout << std::endl
+              << std::endl
+              << "*** Error during initialization!" << std::endl;
     throw std::length_error("Ipopt could not initialize correctly");
   }
 
   // check the jacobian_approximation method
   std::string jac_type = "";
   ipopt_app_->Options()->GetStringValue("jacobian_approximation", jac_type, "");
-  bool finite_diff = jac_type=="finite-difference-values";
+  bool finite_diff = jac_type == "finite-difference-values";
 
   // convert the NLP problem to Ipopt
-  SmartPtr<TNLP> nlp_ptr = new IpoptAdapter(nlp,finite_diff);
-  status_ = ipopt_app_->OptimizeTNLP(nlp_ptr);
+  SmartPtr<TNLP> nlp_ptr = new IpoptAdapter(nlp, finite_diff);
+  status_                = ipopt_app_->OptimizeTNLP(nlp_ptr);
 
   if (status_ != Solve_Succeeded) {
-    std::string msg = "ERROR: Ipopt failed to find a solution. Return Code: " + std::to_string(status_) + "\n";
+    std::string msg = "ERROR: Ipopt failed to find a solution. Return Code: " +
+                      std::to_string(status_) + "\n";
     std::cerr << msg;
   }
 }
 
-void
-IpoptSolver::SetOption (const std::string& name, const std::string& value)
+void IpoptSolver::SetOption(const std::string& name, const std::string& value)
 {
   ipopt_app_->Options()->SetStringValue(name, value);
 }
 
-void
-IpoptSolver::SetOption (const std::string& name, int value)
+void IpoptSolver::SetOption(const std::string& name, int value)
 {
   ipopt_app_->Options()->SetIntegerValue(name, value);
 }
 
-void
-IpoptSolver::SetOption (const std::string& name, double value)
+void IpoptSolver::SetOption(const std::string& name, double value)
 {
   ipopt_app_->Options()->SetNumericValue(name, value);
 }
 
-double
-IpoptSolver::GetTotalWallclockTime ()
+double IpoptSolver::GetTotalWallclockTime()
 {
   return ipopt_app_->Statistics()->TotalWallclockTime();
 }

--- a/ifopt_ipopt/test/ex_test_ipopt.cc
+++ b/ifopt_ipopt/test/ex_test_ipopt.cc
@@ -26,8 +26,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>
 
-#include <ifopt/problem.h>
 #include <ifopt/ipopt_solver.h>
+#include <ifopt/problem.h>
 #include <ifopt/test_vars_constr_cost.h>
 
 using namespace ifopt;
@@ -36,9 +36,9 @@ int main()
 {
   // 1. define the problem
   Problem nlp;
-  nlp.AddVariableSet  (std::make_shared<ExVariables>());
+  nlp.AddVariableSet(std::make_shared<ExVariables>());
   nlp.AddConstraintSet(std::make_shared<ExConstraint>());
-  nlp.AddCostSet      (std::make_shared<ExCost>());
+  nlp.AddCostSet(std::make_shared<ExCost>());
   nlp.PrintCurrent();
 
   // 2. choose solver and options
@@ -52,7 +52,7 @@ int main()
   std::cout << x.transpose() << std::endl;
 
   // 4. test if solution correct
-  double eps = 1e-5; //double precision
-  assert(1.0-eps < x(0) && x(0) < 1.0+eps);
-  assert(0.0-eps < x(1) && x(1) < 0.0+eps);
+  double eps = 1e-5;  //double precision
+  assert(1.0 - eps < x(0) && x(0) < 1.0 + eps);
+  assert(0.0 - eps < x(1) && x(1) < 0.0 + eps);
 }

--- a/ifopt_snopt/include/ifopt/snopt_adapter.h
+++ b/ifopt_snopt/include/ifopt/snopt_adapter.h
@@ -46,8 +46,8 @@ namespace ifopt {
  * functionality, but merely delegate it to the Adaptee (the Problem object).
  */
 class SnoptAdapter : public snoptProblemA {
-public:
-  using NLPPtr  = Problem*;
+ public:
+  using NLPPtr   = Problem*;
   using VectorXd = Problem::VectorXd;
   using Jacobian = Problem::Jacobian;
 
@@ -55,44 +55,43 @@ public:
    * @brief  Creates an Adapter Object around the problem to conform to the
    * Snopt interface.
    */
-  SnoptAdapter (Problem& nlp);
-  virtual ~SnoptAdapter () = default;
+  SnoptAdapter(Problem& nlp);
+  virtual ~SnoptAdapter() = default;
 
   void Init();
   void SetVariables();
 
-  static void ObjectiveAndConstraintFct(int   *Status, int *n,    double x[],
-                                        int   *needF,  int *neF,  double F[],
-                                        int   *needG,  int *neG,  double G[],
-                                        char     *cu,  int *lencu,
-                                        int     iu[],  int *leniu,
-                                        double  ru[],  int *lenru);
+  static void ObjectiveAndConstraintFct(int* Status, int* n, double x[],
+                                        int* needF, int* neF, double F[],
+                                        int* needG, int* neG, double G[],
+                                        char* cu, int* lencu, int iu[],
+                                        int* leniu, double ru[], int* lenru);
 
-private:
-  static NLPPtr nlp_; // use raw pointer as SnoptAdapter doesn't own the nlp.
+ private:
+  static NLPPtr nlp_;  // use raw pointer as SnoptAdapter doesn't own the nlp.
 
 // additional variables as Snopt76 base class doesn't have them, not really
 // necessary but to keep the same structure of the original SnoptAdapter
 #ifdef SNOPT76
 
-public:
-  int     jacComputed = 0;
-  int     n = 0;
-  int     neF = 0;
-  int     ObjRow;
-  double  ObjAdd;
+ public:
+  int jacComputed = 0;
+  int n           = 0;
+  int neF         = 0;
+  int ObjRow;
+  double ObjAdd;
 
   double *x, *xlow, *xupp, *xmul;
   double *F, *Flow, *Fupp, *Fmul;
 
-  int    *xstate, *Fstate;
+  int *xstate, *Fstate;
 
-  int     lenA, lenG, neA, neG;
-  int    *iAfun, *jAvar, *iGfun, *jGvar;
-  double *A;
+  int lenA, lenG, neA, neG;
+  int *iAfun, *jAvar, *iGfun, *jGvar;
+  double* A;
 #endif
 };
 
-} /* namespace opt */
+}  // namespace ifopt
 
 #endif /* IFOPT_INCLUDE_OPT_SNOPT_ADAPTER_H_ */

--- a/ifopt_snopt/include/ifopt/snopt_solver.h
+++ b/ifopt_snopt/include/ifopt/snopt_solver.h
@@ -38,14 +38,14 @@ namespace ifopt {
  * @ingroup Solvers
  */
 class SnoptSolver : public Solver {
-public:
+ public:
   using Ptr = std::shared_ptr<SnoptSolver>;
 
   /**
    * @brief Creates a snoptProblemA from @a nlp and solves it.
    * @param [in/out]  nlp  The specific problem to be used and modified.
    */
-  void Solve(Problem& nlp) override ;
+  void Solve(Problem& nlp) override;
 };
 
 } /* namespace ifopt */

--- a/ifopt_snopt/src/snopt_adapter.cc
+++ b/ifopt_snopt/src/snopt_adapter.cc
@@ -30,78 +30,84 @@ namespace ifopt {
 
 SnoptAdapter::NLPPtr SnoptAdapter::nlp_;
 
-SnoptAdapter::SnoptAdapter (Problem& ref)
+SnoptAdapter::SnoptAdapter(Problem& ref)
 {
   nlp_ = &ref;
 }
 
-void
-SnoptAdapter::Init ()
+void SnoptAdapter::Init()
 {
-  int obj_count = nlp_->HasCostTerms()? 1 : 0;
-  n     = nlp_->GetNumberOfOptimizationVariables();
-  neF   = nlp_->GetNumberOfConstraints() + obj_count;
+  int obj_count = nlp_->HasCostTerms() ? 1 : 0;
+  n             = nlp_->GetNumberOfOptimizationVariables();
+  neF           = nlp_->GetNumberOfConstraints() + obj_count;
 
   x      = new double[n];
   xlow   = new double[n];
   xupp   = new double[n];
   xmul   = new double[n];
-  xstate = new    int[n];
+  xstate = new int[n];
 
   F      = new double[neF];
   Flow   = new double[neF];
   Fupp   = new double[neF];
   Fmul   = new double[neF];
-  Fstate = new    int[neF];
+  Fstate = new int[neF];
 
   // Set the upper and lower bounds.
   // no bounds on the spline coefficients or footholds
   auto bounds_x = nlp_->GetBoundsOnOptimizationVariables();
-  for (std::size_t _n=0; _n<bounds_x.size(); ++_n) {
-    xlow[_n] = bounds_x.at(_n).lower_;
-    xupp[_n] = bounds_x.at(_n).upper_;
+  for (std::size_t _n = 0; _n < bounds_x.size(); ++_n) {
+    xlow[_n]   = bounds_x.at(_n).lower_;
+    xupp[_n]   = bounds_x.at(_n).upper_;
     xstate[_n] = 0;
   }
 
   // bounds on the cost function if it exists
   int c = 0;
   if (nlp_->HasCostTerms()) {
-    Flow[c] = -1e20; Fupp[c] = 1e20; Fmul[c] = 0.0; // no bounds on cost function
+    Flow[c] = -1e20;
+    Fupp[c] = 1e20;
+    Fmul[c] = 0.0;  // no bounds on cost function
     c++;
   }
 
   // bounds on equality and inequality constraints
   auto bounds_g = nlp_->GetBoundsOnConstraints();
   for (const auto& b : bounds_g) {
-    Flow[c] = b.lower_; Fupp[c] = b.upper_; Fmul[c] = 0.0;
+    Flow[c] = b.lower_;
+    Fupp[c] = b.upper_;
+    Fmul[c] = 0.0;
     c++;
   }
 
   // initial values of the optimization
-  VectorXd x_all = nlp_->GetVariableValues();
+  VectorXd x_all                            = nlp_->GetVariableValues();
   Eigen::Map<VectorXd>(&x[0], x_all.rows()) = x_all;
 
-  ObjRow  = nlp_->HasCostTerms()? 0 : -1; // the row in user function that corresponds to the objective function
-  ObjAdd  = 0.0;                          // the constant to be added to the objective function
+  ObjRow =
+      nlp_->HasCostTerms()
+          ? 0
+          : -1;  // the row in user function that corresponds to the objective function
+  ObjAdd = 0.0;  // the constant to be added to the objective function
 
   // no linear derivatives/just assume all are nonlinear
-  lenA = 0;
-  neA = 0;
+  lenA  = 0;
+  neA   = 0;
   iAfun = nullptr;
   jAvar = nullptr;
-  A = nullptr;
+  A     = nullptr;
 
   // derivatives of nonlinear part
-  lenG  = obj_count*n + nlp_->GetJacobianOfConstraints().nonZeros();
+  lenG  = obj_count * n + nlp_->GetJacobianOfConstraints().nonZeros();
   iGfun = new int[lenG];
   jGvar = new int[lenG];
 
   // the gradient terms of the cost function
-  neG=0; // nonzero cells in jacobian of Cost Function AND Constraints
+  neG = 0;  // nonzero cells in jacobian of Cost Function AND Constraints
 
   // the nonzero elements of cost function (assume all)
-  if(nlp_->HasCostTerms()) {
-    for (int var=0; var<n; ++var) {
+  if (nlp_->HasCostTerms()) {
+    for (int var = 0; var < n; ++var) {
       iGfun[neG] = 0;
       jGvar[neG] = var;
       neG++;
@@ -110,8 +116,8 @@ SnoptAdapter::Init ()
 
   // the nonzero elements of constraints (assume all)
   auto jac = nlp_->GetJacobianOfConstraints();
-  for (int k=0; k<jac.outerSize(); ++k) {
-    for (Jacobian::InnerIterator it(jac,k); it; ++it) {
+  for (int k = 0; k < jac.outerSize(); ++k) {
+    for (Jacobian::InnerIterator it(jac, k); it; ++it) {
       iGfun[neG] = it.row() + obj_count;
       jGvar[neG] = it.col();
       neG++;
@@ -121,46 +127,44 @@ SnoptAdapter::Init ()
   setUserFun(&SnoptAdapter::ObjectiveAndConstraintFct);
 }
 
-void
-SnoptAdapter::ObjectiveAndConstraintFct (int* Status, int* n, double x[],
-                                         int* needF, int* neF, double F[],
-                                         int* needG, int* neG, double G[],
-                                         char* cu, int* lencu, int iu[],
-                                         int* leniu, double ru[], int* lenru)
+void SnoptAdapter::ObjectiveAndConstraintFct(int* Status, int* n, double x[],
+                                             int* needF, int* neF, double F[],
+                                             int* needG, int* neG, double G[],
+                                             char* cu, int* lencu, int iu[],
+                                             int* leniu, double ru[],
+                                             int* lenru)
 {
-  if ( *needF > 0 ) {
-    int i=0;
+  if (*needF > 0) {
+    int i = 0;
 
     // the scalar objective function value
     if (nlp_->HasCostTerms())
       F[i++] = nlp_->EvaluateCostFunction(x);
 
     // the vector of constraint values
-    VectorXd g_eig = nlp_->EvaluateConstraints(x);
-    Eigen::Map<VectorXd>(F+i, g_eig.rows()) = g_eig;
+    VectorXd g_eig                            = nlp_->EvaluateConstraints(x);
+    Eigen::Map<VectorXd>(F + i, g_eig.rows()) = g_eig;
   }
 
-
-  if ( *needG > 0 ) {
-    int i=0;
+  if (*needG > 0) {
+    int i = 0;
 
     // the jacobian of the first row (cost function)
     if (nlp_->HasCostTerms()) {
-      Eigen::VectorXd grad = nlp_->EvaluateCostFunctionGradient(x, false);
-      i = grad.rows();
+      Eigen::VectorXd grad       = nlp_->EvaluateCostFunctionGradient(x, false);
+      i                          = grad.rows();
       Eigen::Map<VectorXd>(G, i) = grad;
     }
 
     // the jacobian of all the constraints
-    nlp_->EvalNonzerosOfJacobian(x, G+i);
+    nlp_->EvalNonzerosOfJacobian(x, G + i);
     nlp_->SaveCurrent();
   }
 }
 
-void
-SnoptAdapter::SetVariables ()
+void SnoptAdapter::SetVariables()
 {
   nlp_->SetVariables(x);
 }
 
-} /* namespace opt */
+}  // namespace ifopt

--- a/ifopt_snopt/src/snopt_solver.cc
+++ b/ifopt_snopt/src/snopt_solver.cc
@@ -24,56 +24,58 @@ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************************************************************/
 
-#include <ifopt/snopt_solver.h>
 #include <ifopt/snopt_adapter.h>
+#include <ifopt/snopt_solver.h>
 
 namespace ifopt {
 
-void
-SnoptSolver::Solve (Problem& ref)
+void SnoptSolver::Solve(Problem& ref)
 {
   SnoptAdapter snopt(ref);
   snopt.Init();
 
   // A complete list of options can be found in the snopt user guide:
   // https://web.stanford.edu/group/SOL/guides/sndoc7.pdf
-  snopt.setProbName( "snopt" );
-  snopt.setIntParameter( "Major Print level", 1 );
-  snopt.setIntParameter( "Minor Print level", 1 );
-  snopt.setIntParameter( "Derivative option", 1 ); // 1 = snopt will not calculate missing derivatives
-  snopt.setIntParameter( "Verify level ", 3 ); // full check on gradients, will throw error
+  snopt.setProbName("snopt");
+  snopt.setIntParameter("Major Print level", 1);
+  snopt.setIntParameter("Minor Print level", 1);
+  snopt.setIntParameter("Derivative option",
+                        1);  // 1 = snopt will not calculate missing derivatives
+  snopt.setIntParameter("Verify level ",
+                        3);  // full check on gradients, will throw error
   snopt.setIntParameter("Iterations limit", 200000);
-  snopt.setRealParameter( "Major feasibility tolerance",  1.0e-4); // target nonlinear constraint violation
-  snopt.setRealParameter( "Minor feasibility tolerance",  1.0e-4); // for satisfying the QP bounds
-  snopt.setRealParameter( "Major optimality tolerance",   1.0e-2); // target complementarity gap
-
+  snopt.setRealParameter("Major feasibility tolerance",
+                         1.0e-4);  // target nonlinear constraint violation
+  snopt.setRealParameter("Minor feasibility tolerance",
+                         1.0e-4);  // for satisfying the QP bounds
+  snopt.setRealParameter("Major optimality tolerance",
+                         1.0e-2);  // target complementarity gap
 
   // error codes as given in the manual.
-  int Cold = 0; // Basis = 1, Warm = 2;
-
+  int Cold = 0;  // Basis = 1, Warm = 2;
 
   // interface changed with snopt version 7.6
 #ifdef SNOPT76
-  int nS = 0; // number of super-basic variables (not relevant for cold start)
-  int nInf;   // nInf : number of constraints outside of the bounds
-  double sInf;// sInf : sum of infeasibilities
+  int nS = 0;   // number of super-basic variables (not relevant for cold start)
+  int nInf;     // nInf : number of constraints outside of the bounds
+  double sInf;  // sInf : sum of infeasibilities
 
-  status_  = snopt.solve(Cold, snopt.neF, snopt.n, snopt.ObjAdd,
-                     snopt.ObjRow, &SnoptAdapter::ObjectiveAndConstraintFct,
-                     snopt.iAfun, snopt.jAvar, snopt.A, snopt.neA,
-                     snopt.iGfun, snopt.jGvar, snopt.neG,
-                     snopt.xlow, snopt.xupp, snopt.Flow, snopt.Fupp,
-                     snopt.x, snopt.xstate, snopt.xmul,
-                     snopt.F, snopt.Fstate, snopt.Fmul,
-                     nS, nInf, sInf);
+  status_ = snopt.solve(
+      Cold, snopt.neF, snopt.n, snopt.ObjAdd, snopt.ObjRow,
+      &SnoptAdapter::ObjectiveAndConstraintFct, snopt.iAfun, snopt.jAvar,
+      snopt.A, snopt.neA, snopt.iGfun, snopt.jGvar, snopt.neG, snopt.xlow,
+      snopt.xupp, snopt.Flow, snopt.Fupp, snopt.x, snopt.xstate, snopt.xmul,
+      snopt.F, snopt.Fstate, snopt.Fmul, nS, nInf, sInf);
 #else
   status_ = snopt.solve(Cold);
 #endif
 
-  int EXIT = status_ - status_%10; // change least significant digit to zero
+  int EXIT = status_ - status_ % 10;  // change least significant digit to zero
 
   if (EXIT != 0) {
-    std::string msg = "ERROR: Snopt failed to find a solution. EXIT:" + std::to_string(EXIT) + ", INFO:" + std::to_string(status_) + "\n";
+    std::string msg =
+        "ERROR: Snopt failed to find a solution. EXIT:" + std::to_string(EXIT) +
+        ", INFO:" + std::to_string(status_) + "\n";
     throw std::runtime_error(msg);
   }
 

--- a/ifopt_snopt/test/ex_test_snopt.cc
+++ b/ifopt_snopt/test/ex_test_snopt.cc
@@ -30,16 +30,15 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ifopt/snopt_solver.h>
 #include <ifopt/test_vars_constr_cost.h>
 
-
 using namespace ifopt;
 
 int main()
 {
   Problem nlp;
 
-  nlp.AddVariableSet  (std::make_shared<ExVariables>());
+  nlp.AddVariableSet(std::make_shared<ExVariables>());
   nlp.AddConstraintSet(std::make_shared<ExConstraint>());
-  nlp.AddCostSet      (std::make_shared<ExCost>());
+  nlp.AddCostSet(std::make_shared<ExCost>());
   nlp.PrintCurrent();
 
   SnoptSolver solver;


### PR DESCRIPTION
This PR is applying the actual Google Style to all cpp files as mentioned in the CONTRIBUTING.md file.

For reference I used the following clang-format arguments:

```
{"Language": "Cpp", "BasedOnStyle": "Google", "AccessModifierOffset": -1, "AlignAfterOpenBracket": "Align", "AlignConsecutiveAssignments": true, "AlignOperands": "Align", "AllowAllArgumentsOnNextLine": true, "AllowAllConstructorInitializersOnNextLine": true, "AllowAllParametersOfDeclarationOnNextLine": false, "AllowShortBlocksOnASingleLine": "Empty", "AllowShortCaseLabelsOnASingleLine": false, "AllowShortFunctionsOnASingleLine": "Inline", "AllowShortIfStatementsOnASingleLine": "Never", "AllowShortLambdasOnASingleLine": "Inline", "AllowShortLoopsOnASingleLine": false, "AlwaysBreakAfterReturnType": "None", "AlwaysBreakTemplateDeclarations": "Yes", "BinPackArguments": true, "BreakBeforeBraces": "Custom", "BraceWrapping": {"AfterCaseLabel": false, "AfterClass": false, "AfterStruct": false, "AfterControlStatement": "Never", "AfterEnum": false, "AfterFunction": true, "AfterNamespace": false, "AfterUnion": false, "AfterExternBlock": false, "BeforeCatch": false, "BeforeElse": false, "BeforeLambdaBody": false, "IndentBraces": false, "SplitEmptyFunction": false, "SplitEmptyRecord": false, "SplitEmptyNamespace": false}, "BreakBeforeBinaryOperators": "None", "BreakBeforeTernaryOperators": true, "BreakConstructorInitializers": "BeforeColon", "BreakInheritanceList": "BeforeColon", "ColumnLimit": 80, "CompactNamespaces": false, "ContinuationIndentWidth": 4, "Cpp11BracedListStyle": true, "DerivePointerAlignment": false, "EmptyLineBeforeAccessModifier": "LogicalBlock", "FixNamespaceComments": true, "IncludeBlocks": "Preserve", "IndentCaseLabels": true, "IndentPPDirectives": "None", "IndentWidth": 2, "KeepEmptyLinesAtTheStartOfBlocks": true, "MaxEmptyLinesToKeep": 1, "NamespaceIndentation": "None", "ObjCSpaceAfterProperty": false, "ObjCSpaceBeforeProtocolList": true, "PointerAlignment": "Left", "ReflowComments": false, "SpaceAfterCStyleCast": false, "SpaceAfterLogicalNot": false, "SpaceAfterTemplateKeyword": true, "SpaceBeforeAssignmentOperators": true, "SpaceBeforeCpp11BracedList": false, "SpaceBeforeCtorInitializerColon": true, "SpaceBeforeInheritanceColon": true, "SpaceBeforeParens": "ControlStatements", "SpaceBeforeRangeBasedForLoopColon": true, "SpaceBeforeSquareBrackets": false, "SpaceInEmptyParentheses": false, "SpacesBeforeTrailingComments": 2, "SpacesInAngles": false, "SpacesInCStyleCastParentheses": false, "SpacesInContainerLiterals": false, "SpacesInParentheses": false, "SpacesInSquareBrackets": false, "Standard": "c++11", "TabWidth": 4, "UseTab": "Never"}
```

I copy-paste this into vscode's clang-format integration and get automatic formatting :)