### PR TITLE
Remove unused paramter error

### DIFF
--- a/ifopt_core/include/ifopt/constraint_set.h
+++ b/ifopt_core/include/ifopt/constraint_set.h
@@ -126,10 +126,10 @@ class ConstraintSet : public Component {
    * or shorthands to specific variable sets want to be saved for quicker
    * access later. This function can be overwritten for that.
    */
-  virtual void InitVariableDependedQuantities(const VariablesPtr& x_init){};
+  virtual void InitVariableDependedQuantities(const VariablesPtr& x_init){(void) x_init;};
 
   // doesn't exist for constraints, generated run-time error when used
-  void SetVariables(const VectorXd& x) final { assert(false); };
+  void SetVariables(const VectorXd& x) final { (void) x; assert(false); };
 };
 
 }  // namespace ifopt

--- a/ifopt_core/include/ifopt/constraint_set.h
+++ b/ifopt_core/include/ifopt/constraint_set.h
@@ -126,10 +126,10 @@ class ConstraintSet : public Component {
    * or shorthands to specific variable sets want to be saved for quicker
    * access later. This function can be overwritten for that.
    */
-  virtual void InitVariableDependedQuantities(const VariablesPtr& x_init){(void) x_init;};
+  virtual void InitVariableDependedQuantities(const VariablesPtr& /*x_init*/){};
 
   // doesn't exist for constraints, generated run-time error when used
-  void SetVariables(const VectorXd& x) final { (void) x; assert(false); };
+  void SetVariables(const VectorXd& /*x*/) final { assert(false); };
 };
 
 }  // namespace ifopt


### PR DESCRIPTION
While compiling, constrain set was returning error on unused parameter.

I was considering adding `[[maybe_unused]]` to suppress the error (that would force C++17), or to use `__attribute__((__unused__))` (that would break windows compatibility). Anyway, I decided to use this approach. Hope you find this solution acceptable.