### PR TITLE
Add Hessian Support to IFOPT 

### DIFF
--- a/ifopt_core/include/ifopt/composite.h
+++ b/ifopt_core/include/ifopt/composite.h
@@ -69,6 +69,7 @@ class Component {
   using VecBound = std::vector<Bounds>;
   using Hessian = Eigen::SparseMatrix<double, Eigen::RowMajor>;
   using HessianTriplet = std::vector<Eigen::Triplet<double>>;
+  using RowIndicesHessiansPair = std::pair<std::vector<int>, std::vector<Hessian>>;
 
   /**
    * @brief  Creates a component.
@@ -118,7 +119,7 @@ class Component {
    */
   virtual Jacobian GetJacobian() const = 0;
 
-  virtual std::vector<Hessian> GetHessians() const = 0;
+  virtual RowIndicesHessiansPair GetHessians() const = 0;
 
   /**
    * @brief Returns the number of rows of this component.
@@ -180,7 +181,7 @@ class Composite : public Component {
   // see Component for documentation
   VectorXd GetValues() const override;
   Jacobian GetJacobian() const override;
-  std::vector<Hessian> GetHessians() const override;
+  RowIndicesHessiansPair GetHessians() const override;
   VecBound GetBounds() const override;
   void SetVariables(const VectorXd& x) override;
   void PrintAll() const;

--- a/ifopt_core/include/ifopt/composite.h
+++ b/ifopt_core/include/ifopt/composite.h
@@ -67,6 +67,8 @@ class Component {
   using Jacobian = Eigen::SparseMatrix<double, Eigen::RowMajor>;
   using VectorXd = Eigen::VectorXd;
   using VecBound = std::vector<Bounds>;
+  using Hessian = Eigen::SparseMatrix<double, Eigen::RowMajor>;
+  using HessianTriplet = std::vector<Eigen::Triplet<double>>;
 
   /**
    * @brief  Creates a component.
@@ -115,6 +117,8 @@ class Component {
    * @li Not sensible for Variable.
    */
   virtual Jacobian GetJacobian() const = 0;
+
+  virtual std::vector<Hessian> GetHessians() const = 0;
 
   /**
    * @brief Returns the number of rows of this component.
@@ -176,6 +180,7 @@ class Composite : public Component {
   // see Component for documentation
   VectorXd GetValues() const override;
   Jacobian GetJacobian() const override;
+  std::vector<Hessian> GetHessians() const override;
   VecBound GetBounds() const override;
   void SetVariables(const VectorXd& x) override;
   void PrintAll() const;

--- a/ifopt_core/include/ifopt/constraint_set.h
+++ b/ifopt_core/include/ifopt/constraint_set.h
@@ -107,8 +107,43 @@ class ConstraintSet : public Component {
   virtual void FillJacobianBlock(std::string var_set,
                                  Jacobian& jac_block) const = 0;
 
-
+  /**
+   * @brief  The second-order derivatives (Hessians) for these constraints and variables.
+   *
+   * This function returns a pair containing two vectors. The first vector holds
+   * the indices of the corresponding constraints or costs, while the second vector
+   * contains the Hessian matrices as sparse representations.
+   *
+   * Assuming @c n constraints or costs and @c m variables, each Hessian matrix
+   * in the second vector has dimensions m x m, representing the second-order
+   * derivatives of a specific constraint or cost function with respect to the
+   * optimization variables.
+   *
+   * This function only combines the user-defined Hessians from
+   * FillHessianTriplets().
+   */
   RowIndicesHessiansPair GetHessians() const final;
+
+  /**
+   * @brief Set individual Hessians corresponding to each constraint or cost function.
+   * @param var_set_list  The full set of variables involved in Hessian computation.
+   * @param hessian_row_index_list  Indices of the corresponding constraints or costs.
+   * @param triplets_list  Nonzero elements of each Hessian, stored as triplets.
+   *
+   * This function provides the second-order derivatives (Hessians) of constraints
+   * or costs with respect to the optimization variables. Unlike the Jacobian, Hessians
+   * involve cross-derivatives between different variable sets, so the full variable
+   * set is provided.
+   *
+   * The Hessians are stored efficiently in triplet form to minimize memory usage,
+   * as Hessian matrices are typically much sparser than Jacobians. Each entry in
+   * @c triplets_list corresponds to a specific constraint or cost function, with
+   * its nonzero elements stored as Eigen triplets.
+   *
+   * If a constraint or cost does not require a Hessian, it should simply be omitted
+   * from @c hessian_row_index_list and @c triplets_list. The missing entries will
+   * be treated as empty Hessians.
+   */
   virtual void FillHessianTriplets(std::vector<std::string> var_set_list,
                                    std::vector<int>& hessian_row_index_list,
                                    std::vector<HessianTriplet>& triplets_list) const

--- a/ifopt_core/include/ifopt/constraint_set.h
+++ b/ifopt_core/include/ifopt/constraint_set.h
@@ -107,6 +107,13 @@ class ConstraintSet : public Component {
   virtual void FillJacobianBlock(std::string var_set,
                                  Jacobian& jac_block) const = 0;
 
+
+  std::vector<Hessian> GetHessians() const final;
+  virtual void FillHessianTriplets(std::vector<std::string> var_set_list,
+                                   std::vector<HessianTriplet>& triplets_list) const
+  {
+  }
+
  protected:
   /**
    * @brief Read access to the value of the optimization variables.

--- a/ifopt_core/include/ifopt/constraint_set.h
+++ b/ifopt_core/include/ifopt/constraint_set.h
@@ -108,8 +108,9 @@ class ConstraintSet : public Component {
                                  Jacobian& jac_block) const = 0;
 
 
-  std::vector<Hessian> GetHessians() const final;
+  RowIndicesHessiansPair GetHessians() const final;
   virtual void FillHessianTriplets(std::vector<std::string> var_set_list,
+                                   std::vector<int>& hessian_row_index_list,
                                    std::vector<HessianTriplet>& triplets_list) const
   {
   }

--- a/ifopt_core/include/ifopt/problem.h
+++ b/ifopt_core/include/ifopt/problem.h
@@ -99,6 +99,7 @@ class Problem {
   using Jacobian = Component::Jacobian;
   using VectorXd = Component::VectorXd;
   using Hessian = Component::Hessian;
+  using RowIndicesHessiansPair = Component::RowIndicesHessiansPair;
 
   /**
    * @brief  Creates a optimization problem with no variables, costs or constraints.
@@ -226,8 +227,8 @@ class Problem {
   void EvalNonzerosOfHessian(const double* x, double obj_factor, const double* lambda, double* values);
 
   Hessian GetTotalHessian() const;
-  std::vector<Hessian> GetHessianOfConstraints() const;
-  std::vector<Hessian> GetHessianOfCosts() const;
+  RowIndicesHessiansPair GetHessianOfConstraints() const;
+  RowIndicesHessiansPair GetHessianOfCosts() const;
 
   /**
    * @brief Saves the current values of the optimization variables in x_prev.

--- a/ifopt_core/include/ifopt/problem.h
+++ b/ifopt_core/include/ifopt/problem.h
@@ -98,6 +98,7 @@ class Problem {
   using VecBound = Component::VecBound;
   using Jacobian = Component::Jacobian;
   using VectorXd = Component::VectorXd;
+  using Hessian = Component::Hessian;
 
   /**
    * @brief  Creates a optimization problem with no variables, costs or constraints.
@@ -219,10 +220,13 @@ class Problem {
    * @brief Extracts those entries from total hessian (combination of hessian from cost and constraints) that are not zero.
    * @param [in]  x  The current values of the optimization variables.
    * @param [in]  obj_factor  The scaling multiplier for the hessian of the objective function(cost).
-   * @param [in]  lambda  Lagrange Multipliers of constraints.
+   * @param [in]  lambda  Lagrange Multipliers of the constraints.
    * @param [out] values  The nonzero derivatives ordered by Eigen::RowMajor.
    */
   void EvalNonzerosOfHessian(const double* x, double obj_factor, const double* lambda, double* values);
+
+  std::vector<Hessian> GetHessianOfConstraints() const;
+  std::vector<Hessian> GetHessianOfCosts() const;
 
   /**
    * @brief Saves the current values of the optimization variables in x_prev.

--- a/ifopt_core/include/ifopt/problem.h
+++ b/ifopt_core/include/ifopt/problem.h
@@ -216,6 +216,15 @@ class Problem {
   Jacobian GetJacobianOfCosts() const;
 
   /**
+   * @brief Extracts those entries from total hessian (combination of hessian from cost and constraints) that are not zero.
+   * @param [in]  x  The current values of the optimization variables.
+   * @param [in]  obj_factor  The scaling multiplier for the hessian of the objective function(cost).
+   * @param [in]  lambda  Lagrange Multipliers of constraints.
+   * @param [out] values  The nonzero derivatives ordered by Eigen::RowMajor.
+   */
+  void EvalNonzerosOfHessian(const double* x, double obj_factor, const double* lambda, double* values);
+
+  /**
    * @brief Saves the current values of the optimization variables in x_prev.
    *
    * This is used to keep a history of the values for each NLP iterations.

--- a/ifopt_core/include/ifopt/problem.h
+++ b/ifopt_core/include/ifopt/problem.h
@@ -218,16 +218,61 @@ class Problem {
   Jacobian GetJacobianOfCosts() const;
 
   /**
-   * @brief Extracts those entries from total hessian (combination of hessian from cost and constraints) that are not zero.
+   * @brief Computes the nonzero entries of the total Hessian after applying scaling factors.
+   *
+   * This function extracts the nonzero elements from the total Hessian, which is
+   * the combination of the Hessians from both cost functions and constraints, and
+   * applies the appropriate scaling factors.
+   *
+   * The Hessian of the cost function is multiplied by @c obj_factor, while the
+   * Hessians of the constraints are weighted by their corresponding Lagrange
+   * multipliers in @c lambda.
+   *
    * @param [in]  x  The current values of the optimization variables.
-   * @param [in]  obj_factor  The scaling multiplier for the hessian of the objective function(cost).
-   * @param [in]  lambda  Lagrange Multipliers of the constraints.
-   * @param [out] values  The nonzero derivatives ordered by Eigen::RowMajor.
+   * @param [in]  obj_factor  The scaling multiplier for the Hessian of the objective function (cost).
+   * @param [in]  lambda  The Lagrange multipliers for the constraints.
+   * @param [out] values  The nonzero second-order derivatives, ordered in @c Eigen::RowMajor format.
    */
   void EvalNonzerosOfHessian(const double* x, double obj_factor, const double* lambda, double* values);
 
+  /**
+   * @brief Computes the full Hessian by summing the Hessians of costs and constraints.
+   *
+   * This function returns the total Hessian, which combines the second-order
+   * derivatives of both cost functions and constraints with respect to the
+   * optimization variables.
+   *
+   * The primary purpose of this function is to determine the structure of the
+   * overall Hessian, including the number and positions of nonzero elements.
+   * The resulting matrix is stored in sparse format for efficiency.
+   */
   Hessian GetTotalHessian() const;
+
+  /**
+   * @brief The sparse-matrix representation of the Hessians of the constraints.
+   *
+   * This function returns a pair of vectors, where the first vector contains
+   * the indices of the corresponding constraints, and the second vector holds
+   * the Hessian matrices in sparse format.
+   *
+   * Each Hessian matrix represents the second-order derivatives of a constraint
+   * with respect to the optimization variables. The Hessians are stored sparsely
+   * to optimize memory usage, as they are typically very sparse.
+   */
   RowIndicesHessiansPair GetHessianOfConstraints() const;
+
+
+  /**
+   * @brief The sparse-matrix representation of the Hessians of the cost functions.
+   *
+   * This function returns a pair of vectors, where the first vector contains
+   * the indices of the corresponding cost functions, and the second vector holds
+   * the Hessian matrices in sparse format.
+   *
+   * Each Hessian matrix represents the second-order derivatives of a cost function
+   * with respect to the optimization variables. The Hessians are stored sparsely
+   * to optimize memory usage, as they are typically very sparse.
+   */
   RowIndicesHessiansPair GetHessianOfCosts() const;
 
   /**

--- a/ifopt_core/include/ifopt/problem.h
+++ b/ifopt_core/include/ifopt/problem.h
@@ -225,6 +225,7 @@ class Problem {
    */
   void EvalNonzerosOfHessian(const double* x, double obj_factor, const double* lambda, double* values);
 
+  Hessian GetTotalHessian() const;
   std::vector<Hessian> GetHessianOfConstraints() const;
   std::vector<Hessian> GetHessianOfCosts() const;
 

--- a/ifopt_core/include/ifopt/variable_set.h
+++ b/ifopt_core/include/ifopt/variable_set.h
@@ -58,6 +58,10 @@ class VariableSet : public Component {
   {
     throw std::runtime_error("not implemented for variables");
   };
+  std::vector<Hessian> GetHessians() const final
+  {
+    throw std::runtime_error("not implemented for variables");
+  }
 };
 
 }  // namespace ifopt

--- a/ifopt_core/include/ifopt/variable_set.h
+++ b/ifopt_core/include/ifopt/variable_set.h
@@ -58,7 +58,7 @@ class VariableSet : public Component {
   {
     throw std::runtime_error("not implemented for variables");
   };
-  std::vector<Hessian> GetHessians() const final
+  RowIndicesHessiansPair GetHessians() const final
   {
     throw std::runtime_error("not implemented for variables");
   }

--- a/ifopt_core/src/composite.cc
+++ b/ifopt_core/src/composite.cc
@@ -175,6 +175,25 @@ Composite::Jacobian Composite::GetJacobian() const
   return jacobian;
 }
 
+std::vector<Composite::Hessian> Composite::GetHessians() const
+{
+  if (n_var == -1)
+    n_var = components_.empty() ? 0 : components_.front()->GetHessians().front().cols();
+
+  std::vector<Hessian> hessians;
+  hessians.reserve(GetRows());  // reserve space in the vector to avoid reallocations
+
+  if (n_var == 0)
+    return hessians;
+
+  for (const auto& c : components_) {
+      const std::vector<Hessian>& hess = c->GetHessians();
+      hessians.insert(hessians.end(), hess.begin(), hess.end());
+  }
+
+  return hessians;
+}
+
 Composite::VecBound Composite::GetBounds() const
 {
   VecBound bounds_;

--- a/ifopt_core/src/composite.cc
+++ b/ifopt_core/src/composite.cc
@@ -175,25 +175,41 @@ Composite::Jacobian Composite::GetJacobian() const
   return jacobian;
 }
 
-std::vector<Composite::Hessian> Composite::GetHessians() const
+Composite::RowIndicesHessiansPair Composite::GetHessians() const
 {
-  if (n_var == -1)
-    n_var = components_.empty() ? 0 : components_.front()->GetHessians().front().cols();
+  if (n_var == -1 && components_.empty())
+    n_var = 0;
 
-  std::vector<Hessian> hessians;
+  RowIndicesHessiansPair row_indices_hessians_pair;
+  if (n_var == 0)
+    return row_indices_hessians_pair;
+
+  std::vector<int>& hessian_row_indices = row_indices_hessians_pair.first;
+  hessian_row_indices.reserve(GetRows());
+
+  std::vector<Hessian>& hessians = row_indices_hessians_pair.second;
   hessians.reserve(GetRows());  // reserve space in the vector to avoid reallocations
 
-  if (n_var == 0)
-    return hessians;
-
+  int offset; // offset for row indices in different component
   for (const auto& c : components_) {
-      const std::vector<Hessian>& hess = c->GetHessians();
-      if (!hess.empty()) {
-          hessians.insert(hessians.end(), hess.begin(), hess.end());
-      }
-  }
+    const RowIndicesHessiansPair& local_row_indices_hessians = c->GetHessians();
+    const std::vector<int>& row_indices = local_row_indices_hessians.first;
+    const std::vector<Hessian>& hess = local_row_indices_hessians.second;
+    assert(row_indices.size() == hess.size());
 
-  return hessians;
+    for(int i = 0; i < row_indices.size(); ++i) {
+      hessian_row_indices.push_back(row_indices[i] + offset);
+    }
+    if (!hess.empty()) {
+      if (n_var == -1)
+        n_var = hess.front().cols();
+
+      hessians.insert(hessians.end(), hess.begin(), hess.end());
+    }
+
+    offset += c->GetRows();
+  }
+  return row_indices_hessians_pair;
 }
 
 Composite::VecBound Composite::GetBounds() const

--- a/ifopt_core/src/composite.cc
+++ b/ifopt_core/src/composite.cc
@@ -190,7 +190,7 @@ Composite::RowIndicesHessiansPair Composite::GetHessians() const
   std::vector<Hessian>& hessians = row_indices_hessians_pair.second;
   hessians.reserve(GetRows());  // reserve space in the vector to avoid reallocations
 
-  int offset; // offset for row indices in different component
+  int offset = 0; // offset for row indices in different component
   for (const auto& c : components_) {
     const RowIndicesHessiansPair& local_row_indices_hessians = c->GetHessians();
     const std::vector<int>& row_indices = local_row_indices_hessians.first;

--- a/ifopt_core/src/composite.cc
+++ b/ifopt_core/src/composite.cc
@@ -188,7 +188,9 @@ std::vector<Composite::Hessian> Composite::GetHessians() const
 
   for (const auto& c : components_) {
       const std::vector<Hessian>& hess = c->GetHessians();
-      hessians.insert(hessians.end(), hess.begin(), hess.end());
+      if (!hess.empty()) {
+          hessians.insert(hessians.end(), hess.begin(), hess.end());
+      }
   }
 
   return hessians;

--- a/ifopt_core/src/leaves.cc
+++ b/ifopt_core/src/leaves.cc
@@ -76,19 +76,22 @@ ConstraintSet::Jacobian ConstraintSet::GetJacobian() const
 std::vector<ConstraintSet::Hessian> ConstraintSet::GetHessians() const
 {
   std::vector<HessianTriplet> triplets_list;
+  triplets_list.reserve(GetRows());
 
-  int nrows;
   std::vector<std::string> variable_names;
   for (const auto& vars : variables_->GetComponents()) {
-    nrows += vars->GetRows();
     variable_names.push_back(vars->GetName());
   }
 
   FillHessianTriplets(variable_names, triplets_list);
 
   std::vector<Hessian> hessians;
+  if (triplets_list.empty()) {
+    return hessians;
+  }
   hessians.reserve(GetRows());  // reserve space in the vector to avoid reallocations
 
+  int nrows = variables_->GetRows();
   for (const auto& triplets : triplets_list) {
       Eigen::SparseMatrix<double> H(nrows, nrows);
       H.setFromTriplets(triplets.begin(), triplets.end()); // efficiently construct sparse matrix

--- a/ifopt_core/src/leaves.cc
+++ b/ifopt_core/src/leaves.cc
@@ -73,6 +73,30 @@ ConstraintSet::Jacobian ConstraintSet::GetJacobian() const
   return jacobian;
 }
 
+std::vector<ConstraintSet::Hessian> ConstraintSet::GetHessians() const
+{
+  std::vector<HessianTriplet> triplets_list;
+
+  int nrows;
+  std::vector<std::string> variable_names;
+  for (const auto& vars : variables_->GetComponents()) {
+    nrows += vars->GetRows();
+    variable_names.push_back(vars->GetName());
+  }
+
+  FillHessianTriplets(variable_names, triplets_list);
+
+  std::vector<Hessian> hessians;
+  hessians.reserve(GetRows());  // reserve space in the vector to avoid reallocations
+
+  for (const auto& triplets : triplets_list) {
+      Eigen::SparseMatrix<double> H(nrows, nrows);
+      H.setFromTriplets(triplets.begin(), triplets.end()); // efficiently construct sparse matrix
+      hessians.push_back(H);
+  }
+  return hessians;
+}
+
 void ConstraintSet::LinkWithVariables(const VariablesPtr& x)
 {
   variables_ = x;

--- a/ifopt_core/src/problem.cc
+++ b/ifopt_core/src/problem.cc
@@ -153,6 +153,10 @@ Problem::Jacobian Problem::GetJacobianOfCosts() const
   return costs_.GetJacobian();
 }
 
+void Problem::EvalNonzerosOfHessian(const double* x, double obj_factor, const double* lambda, double* values)
+{
+}
+
 void Problem::SaveCurrent()
 {
   x_prev.push_back(variables_->GetValues());

--- a/ifopt_core/src/problem.cc
+++ b/ifopt_core/src/problem.cc
@@ -157,6 +157,17 @@ void Problem::EvalNonzerosOfHessian(const double* x, double obj_factor, const do
 {
 }
 
+std::vector<Problem::Hessian> Problem::GetHessianOfConstraints() const
+{
+  return constraints_.GetHessians();
+}
+
+std::vector<Problem::Hessian> Problem::GetHessianOfCosts() const
+{
+  return costs_.GetHessians();
+}
+
+
 void Problem::SaveCurrent()
 {
   x_prev.push_back(variables_->GetValues());

--- a/ifopt_core/test/composite_test.cc
+++ b/ifopt_core/test/composite_test.cc
@@ -48,7 +48,7 @@ class ExComponent : public Component {
   {
     throw std::runtime_error("not implemented");
   };
-  virtual std::vector<Hessian> GetHessians() const
+  virtual RowIndicesHessiansPair GetHessians() const
   {
     throw std::runtime_error("not implemented");
   };

--- a/ifopt_core/test/composite_test.cc
+++ b/ifopt_core/test/composite_test.cc
@@ -48,6 +48,10 @@ class ExComponent : public Component {
   {
     throw std::runtime_error("not implemented");
   };
+  virtual std::vector<Hessian> GetHessians() const
+  {
+    throw std::runtime_error("not implemented");
+  };
   virtual void SetVariables(const VectorXd& x){};
 };
 

--- a/ifopt_core/test/ifopt/test_vars_constr_cost.h
+++ b/ifopt_core/test/ifopt/test_vars_constr_cost.h
@@ -144,6 +144,23 @@ class ExConstraint : public ConstraintSet {
           1.0;  // derivative of first constraint w.r.t x1
     }
   }
+
+  void FillHessianTriplets(std::vector<std::string> var_set_list,
+                           std::vector<int>& hessian_row_index_list,
+                           std::vector<HessianTriplet>& triplets_list) const override
+  {
+    // only 1 constraint in this problem
+    HessianTriplet constraint1_triplets;
+    for (int i = 0; i < (int)var_set_list.size(); ++i) {
+      const std::string& var_set = var_set_list[i];
+      if (var_set == "var_set1") {
+        constraint1_triplets.emplace_back(i, i, 2.0); // H(0, 0) = 2.0, dx0^2
+      }
+    }
+    // hessian info for the first constraint
+    hessian_row_index_list.push_back(0);
+    triplets_list.push_back(std::move(constraint1_triplets));
+  }
 };
 
 class ExCost : public CostTerm {
@@ -165,6 +182,22 @@ class ExCost : public CostTerm {
       jac.coeffRef(0, 0) = 0.0;                  // derivative of cost w.r.t x0
       jac.coeffRef(0, 1) = -2.0 * (x(1) - 2.0);  // derivative of cost w.r.t x1
     }
+  }
+
+  void FillHessianTriplets(std::vector<std::string> var_set_list,
+                           std::vector<int>& hessian_row_index_list,
+                           std::vector<HessianTriplet>& triplets_list) const override
+  {
+    HessianTriplet cost_triplets;
+    for (int i = 0; i < (int)var_set_list.size(); ++i) {
+      const std::string& var_set = var_set_list[i];
+      if (var_set == "var_set1") {
+        cost_triplets.emplace_back(i, i, -2.0); // H(0, 0) = -2.0, dx0^2
+      }
+    }
+    // hessian info for the only 1 cost
+    hessian_row_index_list.push_back(0);
+    triplets_list.push_back(std::move(cost_triplets));
   }
 };
 

--- a/ifopt_core/test/ifopt/test_vars_constr_cost.h
+++ b/ifopt_core/test/ifopt/test_vars_constr_cost.h
@@ -149,6 +149,9 @@ class ExConstraint : public ConstraintSet {
                            std::vector<int>& hessian_row_index_list,
                            std::vector<HessianTriplet>& triplets_list) const override
   {
+    // only the upper triangular elements need to be provided, as the Hessian
+    // is symmetric and internally only these values are used.
+
     // only 1 constraint in this problem
     HessianTriplet constraint1_triplets;
     for (int i = 0; i < (int)var_set_list.size(); ++i) {
@@ -188,6 +191,8 @@ class ExCost : public CostTerm {
                            std::vector<int>& hessian_row_index_list,
                            std::vector<HessianTriplet>& triplets_list) const override
   {
+    // only the upper triangular elements need to be provided, as the Hessian
+    // is symmetric and internally only these values are used.
     HessianTriplet cost_triplets;
     for (int i = 0; i < (int)var_set_list.size(); ++i) {
       const std::string& var_set = var_set_list[i];

--- a/ifopt_ipopt/include/ifopt/ipopt_adapter.h
+++ b/ifopt_ipopt/include/ifopt/ipopt_adapter.h
@@ -102,6 +102,15 @@ class IpoptAdapter : public TNLP {
                           Index nele_jac, Index* iRow, Index* jCol,
                           double* values);
 
+  /** Method to return:
+    *   1) The structure of the Hessian of the Lagrangian (if "values" is NULL)
+    *   2) The values of the Hessian of the Lagrangian (if "values" is not NULL)
+    */
+  virtual bool eval_h(Index n, const double* x, bool new_x, double obj_factor,
+                      Index m, const double* lambda, bool new_lambda,
+                      Index nele_hess, Index* iRow, Index* jCol,
+                      double* values);
+
   /** This is called after every iteration and is used to save intermediate
     *  solutions in the nlp */
   virtual bool intermediate_callback(AlgorithmMode mode, Index iter,

--- a/ifopt_ipopt/src/ipopt_adapter.cc
+++ b/ifopt_ipopt/src/ipopt_adapter.cc
@@ -147,6 +147,31 @@ bool IpoptAdapter::eval_jac_g(Index n, const double* x, bool new_x, Index m,
   return true;
 }
 
+bool IpoptAdapter::eval_h(Index n, const double* x, bool new_x, double obj_factor,
+                          Index m, const double* lambda, bool new_lambda,
+                          Index nele_hess, Index* iRow, Index* jCol,
+                          double* values)
+{
+  // defines the positions of the nonzero elements of the hessian
+  if (values == NULL) {
+    Index nele = 0;
+    for (Index row = 0; row < n; row++) {
+      for (Index col = row; col < n; col++) {  // only need upper triangular part because hessian is symmetry matrix
+        iRow[nele] = row;
+        jCol[nele] = col;
+        nele++;
+      }
+    }
+
+    assert(nele ==
+           nele_hess);  // initial sparsity structure is never allowed to change
+  } else {
+    // only gets used if "hessian_approximation" option is "exact"
+    nlp_->EvalNonzerosOfHessian(x, obj_factor, lambda, values);
+  }
+  return true;
+}
+
 bool IpoptAdapter::intermediate_callback(
     AlgorithmMode mode, Index iter, double obj_value, double inf_pr,
     double inf_du, double mu, double d_norm, double regularization_size,

--- a/ifopt_ipopt/test/ex_test_ipopt.cc
+++ b/ifopt_ipopt/test/ex_test_ipopt.cc
@@ -45,6 +45,7 @@ int main()
   IpoptSolver ipopt;
   ipopt.SetOption("linear_solver", "mumps");
   ipopt.SetOption("jacobian_approximation", "exact");
+  ipopt.SetOption("hessian_approximation", "exact");
 
   // 3 . solve
   ipopt.Solve(nlp);


### PR DESCRIPTION
Hi,

I’ve been working on a trajectory optimization project and came across this great interface for the IPOPT library. In my project, I needed custom Hessian functions, so I’ve added Hessian support to the IFOPT project.

There are some design choices I made that I’m not entirely sure align with the project’s philosophy, so I’m open to discussions on those. Specifically, the Hessian matrix interface (FillHessianTriplets) exposes all variable sets because it's difficult to define a pair of variables for the local Hessian matrix, as is done with FillJacobianBlock. This is because Jacobians focus on one variable set at a time, whereas Hessians involve cross-derivatives between different sets.

The decisions I made for the Hessian interface are mostly prioritized for time and space efficiency.

I’ve tested the interface with my own application, and I plan to create a few examples using more complex Hessians based on the original [IPOPT examples](https://github.com/coin-or/Ipopt/tree/stable/3.14/examples/ScalableProblems).

This is my first time contributing to an open-source project, so I hope I’ve done everything correctly!

### Issue link
https://github.com/ethz-adrl/ifopt/issues/41

### TODO
- [ ] Complete documentation related to Hessian support
- [ ] Add more examples with more complex Hessians
- [ ] Cache hessian if its constant