### PR TITLE
Add direct cassert include for Eigen3 >= 5

### DIFF
--- a/ifopt_core/include/ifopt/constraint_set.h
+++ b/ifopt_core/include/ifopt/constraint_set.h
@@ -30,6 +30,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef IFOPT_INCLUDE_IFOPT_CONSTRAINT_SET_H_
 #define IFOPT_INCLUDE_IFOPT_CONSTRAINT_SET_H_
 
+#include <cassert>
+
 #include "composite.h"
 
 namespace ifopt {

--- a/ifopt_core/src/composite.cc
+++ b/ifopt_core/src/composite.cc
@@ -29,6 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ifopt/composite.h>
 
+#include <cassert>
 #include <iomanip>
 #include <iostream>
 


### PR DESCRIPTION
It looks like newer Eigen3 may have removed a cassert include which was transitively used. Adding these helps fix some failures seen when testing Eigen3 5.0.0 in Homebrew (https://github.com/Homebrew/homebrew-core/pull/246477).